### PR TITLE
Fix unreadable dropdowns on Linux

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -55,14 +55,35 @@ body {
   display: block;
 }
 
+/* Force custom styling on native selects. Without appearance:none, GTK/Linux
+   renders native chrome that ignores the dark background, leaving near-white
+   text on a light widget (unreadable). The custom caret replaces the native
+   one that appearance:none removes; option colors fix the dropdown popup. */
+.device-select,
+.cfg-select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%238b93a7' d='M1 1l5 5 5-5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 28px;
+}
+
+.device-select option,
+.cfg-select option {
+  background: var(--panel-2);
+  color: var(--text);
+}
+
 .device-select {
   flex: 1;
   min-width: 0;
-  background: var(--panel-2);
+  background-color: var(--panel-2);
   color: var(--text);
   border: 1px solid var(--line);
   border-radius: 8px;
-  padding: 7px 10px;
+  padding: 7px 28px 7px 10px;
   font-size: 13px;
 }
 
@@ -130,11 +151,11 @@ body {
 }
 
 .cfg-select {
-  background: var(--panel-2);
+  background-color: var(--panel-2);
   color: var(--text);
   border: 1px solid var(--line);
   border-radius: 8px;
-  padding: 6px 10px;
+  padding: 6px 28px 6px 10px;
   font-size: 13px;
 }
 


### PR DESCRIPTION
## Problem

On Ubuntu (and Linux generally), the **device**, **channels**, and **sample rate** dropdowns render with unreadable text — near-white glyphs on a light native widget.

## Cause

The `<select>` elements set a dark CSS background (`--panel-2`) and near-white text (`--text`) but never set `appearance: none`. On Linux, Chromium/Electron falls back to native GTK select chrome, which ignores the CSS background. The result is light text on the light native control. The `<option>` popup had the same issue (system colors).

## Fix

- `appearance: none` (+ vendor prefixes) on both select classes so the CSS background and text color actually apply.
- A custom SVG caret to replace the native arrow that `appearance: none` removes.
- Explicit `background`/`color` on `option` so the dropdown popup is themed too.
- Adjusted `padding-right` to make room for the caret (shorthand `padding` was overriding the shared rule).

macOS/Windows already honored the custom background, so this is a no-op there visually aside from the caret being our own SVG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)