### PR TITLE
Add macOS audio-input entitlement for notarized builds

### DIFF
--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	  Required for microphone/input-device access under the hardened runtime,
+	  which notarization enforces. Without this, signed+notarized builds are
+	  denied audio input even though Info.plist declares NSMicrophoneUsageDescription
+	  (the usage string alone is not sufficient under the hardened runtime).
+	-->
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -33,6 +33,9 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "macOS": {
+      "entitlements": "Entitlements.plist"
+    }
   }
 }


### PR DESCRIPTION
## Problem

The signed + notarized `v0.1.0` macOS build launches fine (Gatekeeper accepts it), but **the microphone doesn't work** — no permission prompt appears, and toggling the mic permission in System Settings has no effect.

Root cause: notarization enforces the **hardened runtime**, under which microphone access requires the `com.apple.security.device.audio-input` entitlement *in addition to* `NSMicrophoneUsageDescription`. The usage string alone is enough for a plain dev build (no hardened runtime) but not for a hardened, notarized build, so audio input is denied silently.

Verified against the shipped artifact — the signed app had **no entitlements embedded at all**:
```
$ codesign -d --entitlements - MeterMaid.app
(empty)
```

## Fix

- Add `src-tauri/Entitlements.plist` declaring `com.apple.security.device.audio-input`.
- Reference it from `tauri.conf.json` → `bundle.macOS.entitlements`.

Tauri applies these entitlements during the hardened-runtime signing step, so the next notarized build will be allowed to request and use the microphone (the standard consent prompt will appear on first launch).

## Verification plan

After merge + re-tag, re-download the macOS DMG and confirm:
```
codesign -d --entitlements - MeterMaid.app   # shows com.apple.security.device.audio-input
```
then launch and confirm the mic permission prompt appears and metering works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)