### PR TITLE
Error messaging, lint tooling, fonts, and UX polish (0.1.1)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "statusMessage": "Running markdownlint…",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); [ -z \"$f\" ] && exit 0; case \"$f\" in *.md) ;; *) exit 0 ;; esac; d=\"${CLAUDE_PROJECT_DIR:-.}\"; bin=\"$d/node_modules/.bin/markdownlint-cli2\"; [ -x \"$bin\" ] || exit 0; cd \"$d\" || exit 0; out=$(\"$bin\" \"$f\" 2>&1); code=$?; if [ $code -ne 0 ]; then printf 'markdownlint found issues in %s:\\n%s\\n' \"$f\" \"$out\" >&2; exit 2; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Pre-commit hook: lint staged Rust, TypeScript, and Markdown.
+#
+# Enabled automatically by the `prepare` npm script, which runs on
+# `pnpm install` and sets `git config core.hooksPath .githooks`.
+#
+# Bypass in an emergency with: git commit --no-verify
+# Skip only the (slower) Rust clippy pass with: SKIP_CLIPPY=1 git commit
+set -uo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)" || exit 1
+cd "$repo_root" || exit 1
+bin="$repo_root/node_modules/.bin"
+
+# Collect staged (added/copied/modified) files by language. Read line by line so
+# paths with spaces survive; avoids bash-4-only features for macOS bash 3.2.
+rs=()
+ts=()
+md=()
+while IFS= read -r f; do
+  case "$f" in
+    *.rs) rs+=("$f") ;;
+    *.ts) ts+=("$f") ;;
+    *.md) md+=("$f") ;;
+  esac
+done < <(git diff --cached --name-only --diff-filter=ACM)
+
+status=0
+
+# --- Markdown -------------------------------------------------------------
+if [ "${#md[@]}" -gt 0 ]; then
+  echo "• markdownlint (${#md[@]} file(s))"
+  if [ -x "$bin/markdownlint-cli2" ]; then
+    "$bin/markdownlint-cli2" "${md[@]}" || status=1
+  else
+    echo "  ! markdownlint-cli2 not found — run 'pnpm install'"
+    status=1
+  fi
+fi
+
+# --- TypeScript -----------------------------------------------------------
+if [ "${#ts[@]}" -gt 0 ]; then
+  echo "• biome (${#ts[@]} file(s))"
+  if [ -x "$bin/biome" ]; then
+    "$bin/biome" check "${ts[@]}" || status=1
+  else
+    echo "  ! biome not found — run 'pnpm install'"
+    status=1
+  fi
+fi
+
+# --- Rust -----------------------------------------------------------------
+if [ "${#rs[@]}" -gt 0 ]; then
+  echo "• rustfmt"
+  (cd src-tauri && cargo fmt --check) || status=1
+  if [ -z "${SKIP_CLIPPY:-}" ]; then
+    echo "• clippy"
+    (cd src-tauri && cargo clippy --all-targets --all-features -- -D warnings) || status=1
+  fi
+fi
+
+if [ "$status" -ne 0 ]; then
+  echo
+  echo "✗ pre-commit checks failed. Fix the issues above, then re-stage."
+  echo "  TypeScript: pnpm format    Rust: (cd src-tauri && cargo fmt)"
+  echo "  Bypass (not recommended):  git commit --no-verify"
+fi
+exit "$status"

--- a/.github/.markdownlint.json
+++ b/.github/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../.markdownlint.json",
+  "MD041": false
+}

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,25 +5,32 @@ title: "[bug] "
 labels: bug
 ---
 
-**Describe the bug**
+## Describe the bug
+
 A clear and concise description of what went wrong.
 
-**To reproduce**
+## To reproduce
+
 Steps to reproduce the behavior:
+
 1. ...
 2. ...
 
-**Expected behavior**
+## Expected behavior
+
 What you expected to happen.
 
-**Audio setup (important for a meter app)**
+## Audio setup (important for a meter app)
+
 - Input device (and how it's connected, e.g. USB / BlackHole):
 - Channels metered (mono / stereo, which indices):
 - Sample rate:
 
-**Environment**
+## Environment
+
 - OS and version:
 - MeterMaid version (or commit):
 
-**Logs / screenshots**
+## Logs / screenshots
+
 Any console output or screenshots that help.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,14 +5,18 @@ title: "[feature] "
 labels: enhancement
 ---
 
-**What problem would this solve?**
+## What problem would this solve?
+
 Describe the use case or pain point. (e.g. "When normalizing Helix patches I need …")
 
-**Proposed solution**
+## Proposed solution
+
 What you'd like MeterMaid to do.
 
-**Alternatives considered**
+## Alternatives considered
+
 Any workarounds or other approaches.
 
-**Additional context**
+## Additional context
+
 Anything else — references to standards (BS.1770 / R128), screenshots, etc.

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD024": { "siblings_only": true }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,50 +2,41 @@
 
 All notable changes to MeterMaid are documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-06-22
+
 ### Changed
-- Capture failures now produce plain-language, actionable messages instead of
-  raw backend strings — they name the device, suggest a fix (e.g. reconnect the
-  device or try a different sample rate), and add an OS-specific hint to check
-  microphone permission when a start fails for an opaque reason.
-- Errors are now shown in a dismissible banner with the full, selectable message
-  and a **Copy** button (plus a link to the issue tracker) so they can be read
-  and reported, rather than truncated in the toolbar status.
+
+- Capture failures now produce plain-language, actionable messages instead of raw backend strings — they name the device, suggest a fix (e.g. reconnect the device or try a different sample rate), and add an OS-specific hint to check microphone permission when a start fails for an opaque reason.
+- Errors are now shown in a dismissible banner with the full, selectable message and a **Copy** button (plus a link to the issue tracker) so they can be read and reported, rather than truncated in the toolbar status.
+- The default target loudness is now −20 LUFS (was −14). Only affects fresh installs; a previously saved target is still restored.
+- While capturing, **Reset** is now the prominent (amber) primary control — the action you take between patch changes — and **Stop** is a quiet secondary button; Reset is hidden when idle. A one-time hint on first capture explains the Reset-between-patches workflow.
+- The UI now bundles its fonts (Inter for the interface, JetBrains Mono for the numeric readouts and spectrum labels) so typography is identical on macOS, Windows, and Linux instead of falling back to each OS's default fonts.
+
+### Fixed
+
+- The Target and Ceiling steppers are now custom, theme-styled up/down controls. The native number-input arrows rendered nearly invisibly on the dark theme (and differently on each platform); the replacements are legible and consistent everywhere.
 
 ## [0.1.0] - 2026-06-18
 
 ### Added
-- Initial release: ITU-R BS.1770 / EBU R128 loudness metering (integrated,
-  short-term, momentary, LRA), true-peak with peak-hold, a log-frequency
-  spectrum analyzer, and a target/apply gain helper.
-- Persist configuration between sessions: window size/position/monitor (via
-  `tauri-plugin-window-state`), plus the selected audio device, channels, sample
-  rate, target LUFS, and clip ceiling (via `tauri-plugin-store`). Restored
-  selections are re-validated against the current device — a missing device
-  falls back to the system default with a notice, and out-of-range channels or
-  sample rates fall back gracefully.
-- If the monitor the window was last shown on is gone at launch (e.g. an external
-  display was unplugged), the window is recentered on an available monitor instead
-  of restoring off-screen.
-- Optional **Auto-start** toggle that begins capture on launch when a valid saved
-  device and channels are restored.
-- Surface OS audio stream faults (e.g. the device being unplugged mid-capture)
-  in the UI instead of silently freezing the meter.
+
+- Initial release: ITU-R BS.1770 / EBU R128 loudness metering (integrated, short-term, momentary, LRA), true-peak with peak-hold, a log-frequency spectrum analyzer, and a target/apply gain helper.
+- Persist configuration between sessions: window size/position/monitor (via `tauri-plugin-window-state`), plus the selected audio device, channels, sample rate, target LUFS, and clip ceiling (via `tauri-plugin-store`). Restored selections are re-validated against the current device — a missing device falls back to the system default with a notice, and out-of-range channels or sample rates fall back gracefully.
+- If the monitor the window was last shown on is gone at launch (e.g. an external display was unplugged), the window is recentered on an available monitor instead of restoring off-screen.
+- Optional **Auto-start** toggle that begins capture on launch when a valid saved device and channels are restored.
+- Surface OS audio stream faults (e.g. the device being unplugged mid-capture) in the UI instead of silently freezing the meter.
 
 ### Changed
-- True-peak and spectrum peak-hold ballistics now fall at a fixed dB/second rate,
-  independent of display refresh rate and the engine's emit cadence.
-- The realtime audio callback no longer logs on ring overrun; it tallies dropped
-  samples lock-free and the engine thread reports them, keeping the callback
-  allocation- and lock-free even under overrun.
-- Tightened the webview Content-Security-Policy (`style-src` no longer allows
-  `'unsafe-inline'`).
+
+- True-peak and spectrum peak-hold ballistics now fall at a fixed dB/second rate, independent of display refresh rate and the engine's emit cadence.
+- The realtime audio callback no longer logs on ring overrun; it tallies dropped samples lock-free and the engine thread reports them, keeping the callback allocation- and lock-free even under overrun.
+- Tightened the webview Content-Security-Policy (`style-src` no longer allows `'unsafe-inline'`).
 - CI now also builds and tests on macOS and runs `cargo audit`.
 
 ### Fixed
-- Reject invalid channel selections (more than two channels, or a stereo pair
-  pointing at the same channel) in the audio engine.
+
+- Reject invalid channel selections (more than two channels, or a stereo pair pointing at the same channel) in the audio engine.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Capture failures now produce plain-language, actionable messages instead of
+  raw backend strings — they name the device, suggest a fix (e.g. reconnect the
+  device or try a different sample rate), and add an OS-specific hint to check
+  microphone permission when a start fails for an opaque reason.
+- Errors are now shown in a dismissible banner with the full, selectable message
+  and a **Copy** button (plus a link to the issue tracker) so they can be read
+  and reported, rather than truncated in the toolbar status.
+
 ## [0.1.0] - 2026-06-18
 
 ### Added

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,15 +1,9 @@
 # Code of Conduct
 
-MeterMaid adopts the [Contributor Covenant](https://www.contributor-covenant.org/),
-version 2.1, as its code of conduct. The full text is available at
-<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.
+MeterMaid adopts the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1, as its code of conduct. The full text is available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.
 
-In short: be respectful and constructive. We want participation in this project
-to be a welcoming experience for everyone, regardless of background or
-experience level.
+In short: be respectful and constructive. We want participation in this project to be a welcoming experience for everyone, regardless of background or experience level.
 
 ## Reporting
 
-If you experience or witness unacceptable behavior, please report it privately to
-the maintainer at **david@reverentgeek.com**. Reports will be reviewed and handled
-in confidence.
+If you experience or witness unacceptable behavior, please report it privately to the maintainer at **<david@reverentgeek.com>**. Reports will be reviewed and handled in confidence.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,6 @@
 # Contributing to MeterMaid
 
-Thanks for your interest in improving MeterMaid! This is a small Tauri app (Rust audio
-engine + TypeScript/Vite UI), so the contribution loop is short.
+Thanks for your interest in improving MeterMaid! This is a small Tauri app (Rust audio engine + TypeScript/Vite UI), so the contribution loop is short.
 
 By participating, you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md).
 
@@ -18,12 +17,24 @@ pnpm install
 pnpm tauri dev
 ```
 
+`pnpm install` also enables a Git pre-commit hook (via `core.hooksPath`) that lints any staged Rust, TypeScript, and Markdown before each commit.
+
+## Linting
+
+TypeScript is linted and formatted with [Biome](https://biomejs.dev), Markdown with [markdownlint](https://github.com/DavidAnson/markdownlint), and Rust with `rustfmt` + `clippy`. The pre-commit hook runs these on staged files automatically; you can also run them by hand:
+
+```sh
+pnpm lint      # Biome (TypeScript) + markdownlint (Markdown)
+pnpm format    # apply Biome fixes/formatting
+```
+
 ## Before opening a pull request
 
 Please make sure all of the following pass locally — CI runs the same checks:
 
 ```sh
 # Frontend
+pnpm lint
 pnpm build
 
 # Rust (run from src-tauri/)
@@ -32,17 +43,12 @@ cargo clippy --all-targets --all-features -- -D warnings
 cargo test
 ```
 
-- Run `cargo fmt` to fix formatting.
-- New audio/analysis behavior should come with tests. See the golden-signal suite in
-  `src-tauri/src/audio.rs` (`#[cfg(test)] mod tests`) for the pattern — you can drive the
-  `Analyzer` directly with synthesized frames, no audio device required. If you have
-  `ffmpeg` installed, the ignored cross-check is handy:
-  `cargo test ebur128_matches_ffmpeg -- --ignored --nocapture`.
+- Run `pnpm format` to fix TypeScript formatting and `cargo fmt` to fix Rust formatting.
+- New audio/analysis behavior should come with tests. See the golden-signal suite in `src-tauri/src/audio.rs` (`#[cfg(test)] mod tests`) for the pattern — you can drive the `Analyzer` directly with synthesized frames, no audio device required. If you have `ffmpeg` installed, the ignored cross-check is handy: `cargo test ebur128_matches_ffmpeg -- --ignored --nocapture`.
 
 ## Guidelines
 
-- Keep the realtime audio callback allocation- and lock-free (it only writes into the
-  SPSC ring; all analysis happens on the engine thread). See `audio.rs` for the rationale.
+- Keep the realtime audio callback allocation- and lock-free (it only writes into the SPSC ring; all analysis happens on the engine thread). See `audio.rs` for the rationale.
 - Match the existing code style and keep changes focused.
 - For larger changes, open an issue first to discuss the approach.
 

--- a/README.md
+++ b/README.md
@@ -8,16 +8,13 @@ A cross-platform desktop **LUFS / loudness meter** built with [Tauri](https://ta
 
 ## Download
 
-Grab the installer for your platform below, or see [all releases](https://github.com/reverentgeek/metermaid/releases/latest) for every format and the latest version.
+[**Download the latest release →**](https://github.com/reverentgeek/metermaid/releases/latest)
 
-| Platform | Installer | Other formats |
-| --- | --- | --- |
-| **macOS** (Apple Silicon) | [`.dmg`](https://github.com/reverentgeek/metermaid/releases/download/v0.1.0/MeterMaid_0.1.0_aarch64.dmg) | — |
-| **macOS** (Intel) | [`.dmg`](https://github.com/reverentgeek/metermaid/releases/download/v0.1.0/MeterMaid_0.1.0_x64.dmg) | — |
-| **Windows** (x64) | [`.exe` installer](https://github.com/reverentgeek/metermaid/releases/download/v0.1.0/MeterMaid_0.1.0_x64-setup.exe) | [`.msi`](https://github.com/reverentgeek/metermaid/releases/download/v0.1.0/MeterMaid_0.1.0_x64_en-US.msi) |
-| **Windows** (ARM64) | [`.exe` installer](https://github.com/reverentgeek/metermaid/releases/download/v0.1.0/MeterMaid_0.1.0_arm64-setup.exe) | [`.msi`](https://github.com/reverentgeek/metermaid/releases/download/v0.1.0/MeterMaid_0.1.0_arm64_en-US.msi) |
-| **Linux** (x64) | [`.AppImage`](https://github.com/reverentgeek/metermaid/releases/download/v0.1.0/MeterMaid_0.1.0_amd64.AppImage) | [`.deb`](https://github.com/reverentgeek/metermaid/releases/download/v0.1.0/MeterMaid_0.1.0_amd64.deb) · [`.rpm`](https://github.com/reverentgeek/metermaid/releases/download/v0.1.0/MeterMaid-0.1.0-1.x86_64.rpm) |
-| **Linux** (ARM64) | [`.AppImage`](https://github.com/reverentgeek/metermaid/releases/download/v0.1.0/MeterMaid_0.1.0_aarch64.AppImage) | [`.deb`](https://github.com/reverentgeek/metermaid/releases/download/v0.1.0/MeterMaid_0.1.0_arm64.deb) · [`.rpm`](https://github.com/reverentgeek/metermaid/releases/download/v0.1.0/MeterMaid-0.1.0-1.aarch64.rpm) |
+On the release page, pick the file for your platform:
+
+- **macOS** — `.dmg` (Apple Silicon is `aarch64`, Intel is `x64`)
+- **Windows** — `.exe` installer, or the `.msi` (both `x64` and `arm64` builds)
+- **Linux** — `.AppImage`, or the `.deb` / `.rpm` (both `x64` and `arm64` builds)
 
 macOS builds are signed with an Apple Developer ID and **notarized** by Apple, so they open without Gatekeeper warnings. Windows builds are currently **unsigned**, and SmartScreen may warn on first run (choose *More info → Run anyway*). On first launch, MeterMaid asks for **microphone access**, which it needs to read audio from any input device.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,22 +2,17 @@
 
 ## Supported versions
 
-MeterMaid is pre-1.0; only the latest release on the default branch is supported with
-security fixes.
+MeterMaid is pre-1.0; only the latest release on the default branch is supported with security fixes.
 
 ## Reporting a vulnerability
 
 Please report security issues **privately** rather than opening a public issue.
 
 - Preferred: open a [GitHub private security advisory](https://github.com/reverentgeek/metermaid/security/advisories/new).
-- Or email **david@reverentgeek.com** with details and, if possible, steps to reproduce.
+- Or email **<david@reverentgeek.com>** with details and, if possible, steps to reproduce.
 
-You can expect an acknowledgement within a few days. Once a fix is available it will be
-released and the reporter credited (unless you prefer to remain anonymous).
+You can expect an acknowledgement within a few days. Once a fix is available it will be released and the reporter credited (unless you prefer to remain anonymous).
 
 ## Scope notes
 
-MeterMaid is a local desktop app that captures audio from input devices. It performs no
-network requests and stores no credentials. The most relevant surface is the OS audio
-permission and the Tauri webview, which runs under a restrictive Content-Security-Policy
-(see `src-tauri/tauri.conf.json`).
+MeterMaid is a local desktop app that captures audio from input devices. It performs no network requests and stores no credentials. The most relevant surface is the OS audio permission and the Tauri webview, which runs under a restrictive Content-Security-Policy (see `src-tauri/tauri.conf.json`).

--- a/TODO.md
+++ b/TODO.md
@@ -9,42 +9,30 @@ Future tasks and ideas for the MeterMaid app. Roughly ordered by value.
 Remember and restore app state on launch so the user doesn't reconfigure every time.
 
 - [x] Persist **window size, position, and monitor** across launches.
-  - On startup, if the previously used monitor is **no longer present** (e.g. an
-    external display was unplugged), move the window to the next available monitor
-    instead of restoring it off-screen.
-  - Also clamp the restored position so the window is always at least partially
-    on-screen (guards against resolution changes / display rearrangement).
+  - On startup, if the previously used monitor is **no longer present** (e.g. an external display was unplugged), move the window to the next available monitor instead of restoring it off-screen.
+  - Also clamp the restored position so the window is always at least partially on-screen (guards against resolution changes / display rearrangement).
 - [x] Persist **selected audio device** and re-select it on launch.
   - If that device is gone, fall back to the system default and surface a notice.
 - [x] Persist **selected channels** (e.g. `Ch 1–2`) and **sample rate**.
-  - Re-validate against the restored device's capabilities; fall back gracefully
-    if the channel index / rate is no longer valid.
+  - Re-validate against the restored device's capabilities; fall back gracefully if the channel index / rate is no longer valid.
 - [x] Persist **target LUFS** and **clip ceiling (dBTP)** values.
 - [x] (Optional) Auto-start capture on launch if a valid device + channels restore.
 - [x] Add more frequency labels below the spectral graph so that users have a better idea of which ones are spiking
 
 Implementation notes:
 
-- The [`tauri-plugin-window-state`](https://github.com/tauri-apps/plugins-workspace/tree/v2/plugins/window-state)
-  plugin handles window size/position/monitor restore out of the box — evaluate it
-  before hand-rolling. Confirm its multi-monitor / missing-monitor behavior matches
-  the requirement above; add the fallback logic if not.
-- For app settings (device, channels, rate, target, ceiling), use
-  [`tauri-plugin-store`](https://github.com/tauri-apps/plugins-workspace/tree/v2/plugins/store)
-  (JSON key/value store) rather than inventing a config format.
+- The [`tauri-plugin-window-state`](https://github.com/tauri-apps/plugins-workspace/tree/v2/plugins/window-state) plugin handles window size/position/monitor restore out of the box — evaluate it before hand-rolling. Confirm its multi-monitor / missing-monitor behavior matches the requirement above; add the fallback logic if not.
+- For app settings (device, channels, rate, target, ceiling), use [`tauri-plugin-store`](https://github.com/tauri-apps/plugins-workspace/tree/v2/plugins/store) (JSON key/value store) rather than inventing a config format.
 
 ### "Main output" preset
 
-- [ ] One-click preset that restores a saved device + channel pair (subset of the
-      persistence work above; could ship as soon as device/channel persistence lands).
+- [ ] One-click preset that restores a saved device + channel pair (subset of the persistence work above; could ship as soon as device/channel persistence lands).
 
 ## Distribution
 
-- [ ] **Code signing + notarization (macOS)** — Apple Developer account ($99/yr),
-      Developer ID Application cert. Env vars are already documented in the README.
+- [ ] **Code signing + notarization (macOS)** — Apple Developer account ($99/yr), Developer ID Application cert. Env vars are already documented in the README.
 - [ ] Add hardened-runtime entitlements file (`com.apple.security.device.audio-input`).
-- [ ] Decide on **Windows / Linux** support (changes the signing budget and the
-      webview-audio consistency story — see notes from initial design discussion).
+- [ ] Decide on **Windows / Linux** support (changes the signing budget and the webview-audio consistency story — see notes from initial design discussion).
 - [ ] CI to produce signed builds reproducibly for contributors.
 
 ## Possible enhancements

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,33 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
+	"files": {
+		"includes": ["src/**/*.ts", "vite.config.ts"]
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab",
+		"indentWidth": 2,
+		"lineWidth": 80
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"preset": "recommended",
+			"style": {
+				"noNonNullAssertion": "off"
+			}
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double",
+			"semicolons": "always",
+			"trailingCommas": "all"
+		}
+	}
+}

--- a/index.html
+++ b/index.html
@@ -49,6 +49,16 @@
       </label>
     </div>
 
+    <div id="errorBanner" class="error-banner" hidden>
+      <span class="error-icon" aria-hidden="true">⚠</span>
+      <div class="error-body">
+        <span id="errorMessage" class="error-message" role="alert"></span>
+        <span class="error-report">Still stuck? Report it at github.com/reverentgeek/metermaid/issues</span>
+      </div>
+      <button id="errorCopy" class="btn btn-small" type="button" title="Copy the error details">Copy</button>
+      <button id="errorDismiss" class="error-dismiss" type="button" title="Dismiss" aria-label="Dismiss error">×</button>
+    </div>
+
     <section class="readouts">
       <div class="readout readout-hero">
         <div class="label">Integrated</div>

--- a/index.html
+++ b/index.html
@@ -32,8 +32,9 @@
         <span>MeterMaid</span>
       </div>
       <select id="device" class="device-select" title="Input device"></select>
-      <button id="toggle" class="btn btn-primary">Start</button>
-      <button id="reset" class="btn" title="Restart integrated + peak measurement">Reset</button>
+      <button id="start" class="btn btn-primary">Start</button>
+      <button id="reset" class="btn btn-reset" hidden title="Restart the integrated measurement — click after changing a patch">↻ Reset</button>
+      <button id="stop" class="btn" hidden title="Stop capturing">Stop</button>
       <span id="status" class="status">stopped</span>
     </header>
 
@@ -47,6 +48,12 @@
         <input id="autostart" type="checkbox" />
         Auto-start
       </label>
+    </div>
+
+    <div id="resetHint" class="hint" hidden>
+      <span class="hint-icon" aria-hidden="true">↻</span>
+      <span class="hint-text">Changed your patch? Click <strong>Reset</strong>, then play a few seconds — <strong>Apply</strong> will settle on the new level.</span>
+      <button id="hintDismiss" class="hint-dismiss" type="button" title="Got it" aria-label="Dismiss hint">Got it</button>
     </div>
 
     <div id="errorBanner" class="error-banner" hidden>
@@ -90,7 +97,13 @@
 
     <section class="target-row">
       <label for="target">Target</label>
-      <input id="target" class="num-input" type="number" value="-14" step="0.5" />
+      <div class="num-field">
+        <input id="target" class="num-input" type="number" value="-20" step="0.5" />
+        <span class="num-steppers">
+          <button type="button" class="num-step" data-for="target" data-dir="up" tabindex="-1" aria-label="Increase target"></button>
+          <button type="button" class="num-step" data-for="target" data-dir="down" tabindex="-1" aria-label="Decrease target"></button>
+        </span>
+      </div>
       <span class="unit-inline">LUFS</span>
 
       <span class="spacer"></span>
@@ -98,7 +111,13 @@
       <span class="spacer"></span>
 
       <label for="ceiling">Ceiling</label>
-      <input id="ceiling" class="num-input" type="number" value="-1" step="0.5" />
+      <div class="num-field">
+        <input id="ceiling" class="num-input" type="number" value="-1" step="0.5" />
+        <span class="num-steppers">
+          <button type="button" class="num-step" data-for="ceiling" data-dir="up" tabindex="-1" aria-label="Increase ceiling"></button>
+          <button type="button" class="num-step" data-for="ceiling" data-dir="down" tabindex="-1" aria-label="Decrease ceiling"></button>
+        </span>
+      </div>
       <span class="unit-inline">dBTP</span>
     </section>
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "metermaid",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
-  "packageManager": "pnpm@11.7.0",
+  "packageManager": "pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26",
   "description": "MeterMaid — a cross-platform LUFS / loudness meter built with Tauri",
   "author": "David Neal <david@reverentgeek.com>",
   "license": "MIT",
@@ -19,14 +19,21 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "lint": "biome check && markdownlint-cli2 \"**/*.md\" \"#node_modules\"",
+    "format": "biome check --write",
+    "prepare": "git config core.hooksPath .githooks || true"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.11.1",
-    "@tauri-apps/plugin-store": "^2"
+    "@tauri-apps/plugin-store": "^2.4.3"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^2",
+    "@biomejs/biome": "^2.5.0",
+    "@fontsource/inter": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
+    "@tauri-apps/cli": "^2.11.3",
+    "markdownlint-cli2": "^0.22.1",
     "typescript": "~6.0.3",
     "vite": "^8.0.16"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,12 +12,24 @@ importers:
         specifier: ^2.11.1
         version: 2.11.1
       '@tauri-apps/plugin-store':
-        specifier: ^2
+        specifier: ^2.4.3
         version: 2.4.3
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.5.0
+        version: 2.5.0
+      '@fontsource/inter':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource/jetbrains-mono':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@tauri-apps/cli':
-        specifier: ^2
-        version: 2.11.2
+        specifier: ^2.11.3
+        version: 2.11.3
+      markdownlint-cli2:
+        specifier: ^0.22.1
+        version: 0.22.1
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -26,6 +38,63 @@ importers:
         version: 8.0.16
 
 packages:
+
+  '@biomejs/biome@2.5.0':
+    resolution: {integrity: sha512-4kURkd9hAPrdDM3C9n82ycYgx8hvQcW6MjKTEejruj8rK0N8P3OPpdy8BvI8kt3KWY4ycF5XtDOrktetEfhfuw==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.5.0':
+    resolution: {integrity: sha512-Mn3Fwi3SA5fgmfCPqmzpWF2DLZnms3BVAhM088nTnGrTZmHS3wwIjcoZPqpXeNgd3DrrLH6xp8vTLIBuJoZiXw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.5.0':
+    resolution: {integrity: sha512-rg3VPL5P8mYro6pqlXYXuJWph21slVp3SZtAqWSrkZs40d2gTzYmHF8E/X1iTID25btmNKltNDJ926sqVBp7DQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.5.0':
+    resolution: {integrity: sha512-vQdM4oSGaf7ZNeGO9w5+Y8SBtyser9M6znxYbm7Ec8wInxJu1WiKxFYZW5Auj2d80bcVvefuGGRxoFOE0eee8g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.5.0':
+    resolution: {integrity: sha512-tl+LW8fdD96/xdeWtWwc82LIOc5CoY7N2AsogLTp5R4ECErYt+8Jl/N68ezN9vzSiqPTxw6vjcihoLPYKZHrlw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.5.0':
+    resolution: {integrity: sha512-+9hIcMngJ+yGUahXqZuZ8CoWKJE9SAZsFsM3QDvXpNsLbXZ9lqVzgBhOk/jTSYkOA0GLP9eu3teukqpLUojHMg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.5.0':
+    resolution: {integrity: sha512-zpEGf4RQbFEh8Vt7OmavLyyOzRbtcE9osCqrS1kfvt8jDvxwhKXLSf7n0ebr/ov0RJ9ssP+lhs6C8a9WwFvrQA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.5.0':
+    resolution: {integrity: sha512-jB0wAvTLI4itx5VidqVUejPQFhRUxiZ9l9FvZ26D5fl6t3qme+ZB4PD3bTSeL1vZ8NI2Rx/zj6H9zcESuGHKGw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.5.0':
+    resolution: {integrity: sha512-VT/lF+GId+67j8aDfLkxdxNoVApsPSTbyAtB3jJq0IWTrY77WXfbPfpngxq0bA6JCEv/7k8C9qWjDRKRznDlyw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -36,11 +105,29 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@fontsource/inter@5.2.8':
+    resolution: {integrity: sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==}
+
+  '@fontsource/jetbrains-mono@5.2.8':
+    resolution: {integrity: sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==}
+
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
@@ -143,82 +230,86 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
+
   '@tauri-apps/api@2.11.1':
     resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
 
-  '@tauri-apps/cli-darwin-arm64@2.11.2':
-    resolution: {integrity: sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w==}
+  '@tauri-apps/cli-darwin-arm64@2.11.3':
+    resolution: {integrity: sha512-BxpaM8bsCoXs3wd4WKYhas/G1gs7+r7B+e4WnyRk2GEoVOouJB1hoL6E6YLXZDXbYci6VFdrNnobQwd2uVL4ew==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@tauri-apps/cli-darwin-x64@2.11.2':
-    resolution: {integrity: sha512-VjYYtZUPqDMLutSfJEyxFE3Bz+DPi7c8wC3imckgvciLDZLq4qwKJxBicg0BXGhXjJsl8vKWgWRFNMPELQ+Xyg==}
+  '@tauri-apps/cli-darwin-x64@2.11.3':
+    resolution: {integrity: sha512-DbZYuPB1ZEzcAHYeyCvo3ltzM27+aXwPloCrtexPnmgPgulYJm3TOq6aC4S+wPhSXteddg8zImtNkvx/gQzmwg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.2':
-    resolution: {integrity: sha512-yMemD6f4i95AQriS8EazyOFzbE34yjnP16i3IOzpHGQvBoy2DjypFMFBq0NtPuITURv/cOGguRtHR5d79/9CSA==}
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.3':
+    resolution: {integrity: sha512-741NduqBmz1XkdU8yz3OI/kBZtqHbvxo9F9ytIeWYU69/Ba9dcZEbqOU++Dp0G/XU8vAI0TfTywEl+p+BbLvaA==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
-  '@tauri-apps/cli-linux-arm64-gnu@2.11.2':
-    resolution: {integrity: sha512-cgI91D2wL8GSgoWwZXDqt+DwnuZCP2/bz03QAE4TrhgAKIsrB4hX26W/H1EONPUUNkqrsgeCD0wU6pcNjV/5kw==}
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.3':
+    resolution: {integrity: sha512-RWAXT8pTqIczXcoic+LXlo6uEbAXGB0cgh6Pg7Y9xVnEbzryQ1JHtRGj9SxzrKSemBIDBH6Qc24kK2G69i8ofA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@tauri-apps/cli-linux-arm64-musl@2.11.2':
-    resolution: {integrity: sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw==}
+  '@tauri-apps/cli-linux-arm64-musl@2.11.3':
+    resolution: {integrity: sha512-qomqYS+yAkd0gXMRmhguWXc7RfVN+XKKXaEwbf5QmKURwydLFOTldd6F8/WoZDSsBMrV8dpNxz0YneGLmobiSA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@tauri-apps/cli-linux-riscv64-gnu@2.11.2':
-    resolution: {integrity: sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ==}
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.3':
+    resolution: {integrity: sha512-jOCXbDqeDj5XcclsOBAaXjtTgwZCVg8zEZ+dbPUCoADOgljFgL0rOkYTc96vUYgOrYEfuHYihWMxIDGaD6GwJw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@tauri-apps/cli-linux-x64-gnu@2.11.2':
-    resolution: {integrity: sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw==}
+  '@tauri-apps/cli-linux-x64-gnu@2.11.3':
+    resolution: {integrity: sha512-+u3HO/F3gHwL48t9gWN/urqZvpaEJzBFmTaq5eSIhvy8TOvnhb+LgJr3Q3BG+5JxuBrCUjqtOEz6gMttdJFSBA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@tauri-apps/cli-linux-x64-musl@2.11.2':
-    resolution: {integrity: sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw==}
+  '@tauri-apps/cli-linux-x64-musl@2.11.3':
+    resolution: {integrity: sha512-spr5Jpr6KF/vehkLwJ0YmdGv8QwpWU+uw7J8bgijO0sox6ZCYsSNMbcsQjTqPi4xl+p0woIYpWXgChgHYpAc8g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@tauri-apps/cli-win32-arm64-msvc@2.11.2':
-    resolution: {integrity: sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA==}
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.3':
+    resolution: {integrity: sha512-abkoRQih5xBa3vz2spWaex0kP/MzVzVPQHom2f8jnCq46R/luOD6Uy85EMU9/bfzf6ZzdorWJsgO+OMX90Fx2w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@tauri-apps/cli-win32-ia32-msvc@2.11.2':
-    resolution: {integrity: sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA==}
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.3':
+    resolution: {integrity: sha512-Vy6AvzFm1G40hg3r+OYDB3jkuu7R4wnMzbQBKuun9v6Cgg8IierpLL7toMzrZKs/8NlG8Sg4x1iLFR52oknyHg==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
 
-  '@tauri-apps/cli-win32-x64-msvc@2.11.2':
-    resolution: {integrity: sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA==}
+  '@tauri-apps/cli-win32-x64-msvc@2.11.3':
+    resolution: {integrity: sha512-GlciF75GdbseajOyib2aCHwE3BXIqZ1liGKWLFRvCdN5wm8h8hFssEVKQ/6E+2jsMLg9v7LCTb983YFnn0QSww==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@tauri-apps/cli@2.11.2':
-    resolution: {integrity: sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==}
+  '@tauri-apps/cli@2.11.3':
+    resolution: {integrity: sha512-EElQe8z8uD7Pi5++tJ/UfEwWuK08rd3oCDYdeIbJAb6pZRrxlqmoF5gh5H5YvzmUPhS4IRCaLSsQhvWkrfK+GQ==}
     engines: {node: '>= 10'}
     hasBin: true
 
@@ -228,9 +319,75 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/katex@0.16.8':
+    resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -241,10 +398,73 @@ packages:
       picomatch:
         optional: true
 
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  globby@16.2.0:
+    resolution: {integrity: sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==}
+    engines: {node: '>=20'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-path-inside@4.0.0:
+    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
+    engines: {node: '>=12'}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jsonpointer@5.0.1:
+    resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
+    engines: {node: '>=0.10.0'}
+
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -320,13 +540,130 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  linkify-it@5.0.1:
+    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
+
+  markdownlint-cli2-formatter-default@0.0.6:
+    resolution: {integrity: sha512-VVDGKsq9sgzu378swJ0fcHfSicUnMxnL8gnLm/Q4J/xsNJ4e5bA6lvAz7PCzIl0/No0lHyaWdqVD2jotxOSFMQ==}
+    peerDependencies:
+      markdownlint-cli2: '>=0.0.4'
+
+  markdownlint-cli2@0.22.1:
+    resolution: {integrity: sha512-X14ZbytybDCXAViDmtN4DKLt9ZTrRn+oOrxTYlg3a65jS6QcYYbAkGPh/En2L/GDNbFYJ6lKaQSUNrrbN1bPrw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  markdownlint@0.40.0:
+    resolution: {integrity: sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==}
+    engines: {node: '>=20'}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-directive@4.0.0:
+    resolution: {integrity: sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-math@3.1.0:
+    resolution: {integrity: sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.13:
+    resolution: {integrity: sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -336,18 +673,52 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  slash@5.1.0:
+    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
+    engines: {node: '>=14.16'}
+
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+    engines: {node: '>= 18'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  string-width@8.1.0:
+    resolution: {integrity: sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==}
+    engines: {node: '>=20'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -356,6 +727,13 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  unicorn-magic@0.4.0:
+    resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
+    engines: {node: '>=20'}
 
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
@@ -402,6 +780,41 @@ packages:
 
 snapshots:
 
+  '@biomejs/biome@2.5.0':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.5.0
+      '@biomejs/cli-darwin-x64': 2.5.0
+      '@biomejs/cli-linux-arm64': 2.5.0
+      '@biomejs/cli-linux-arm64-musl': 2.5.0
+      '@biomejs/cli-linux-x64': 2.5.0
+      '@biomejs/cli-linux-x64-musl': 2.5.0
+      '@biomejs/cli-win32-arm64': 2.5.0
+      '@biomejs/cli-win32-x64': 2.5.0
+
+  '@biomejs/cli-darwin-arm64@2.5.0':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.5.0':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.5.0':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.5.0':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.5.0':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.5.0':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.5.0':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.5.0':
+    optional: true
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -418,12 +831,28 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@fontsource/inter@5.2.8': {}
+
+  '@fontsource/jetbrains-mono@5.2.8': {}
+
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
     optional: true
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
 
   '@oxc-project/types@0.133.0': {}
 
@@ -478,54 +907,56 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@sindresorhus/merge-streams@4.0.0': {}
+
   '@tauri-apps/api@2.11.1': {}
 
-  '@tauri-apps/cli-darwin-arm64@2.11.2':
+  '@tauri-apps/cli-darwin-arm64@2.11.3':
     optional: true
 
-  '@tauri-apps/cli-darwin-x64@2.11.2':
+  '@tauri-apps/cli-darwin-x64@2.11.3':
     optional: true
 
-  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.2':
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.3':
     optional: true
 
-  '@tauri-apps/cli-linux-arm64-gnu@2.11.2':
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.3':
     optional: true
 
-  '@tauri-apps/cli-linux-arm64-musl@2.11.2':
+  '@tauri-apps/cli-linux-arm64-musl@2.11.3':
     optional: true
 
-  '@tauri-apps/cli-linux-riscv64-gnu@2.11.2':
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.3':
     optional: true
 
-  '@tauri-apps/cli-linux-x64-gnu@2.11.2':
+  '@tauri-apps/cli-linux-x64-gnu@2.11.3':
     optional: true
 
-  '@tauri-apps/cli-linux-x64-musl@2.11.2':
+  '@tauri-apps/cli-linux-x64-musl@2.11.3':
     optional: true
 
-  '@tauri-apps/cli-win32-arm64-msvc@2.11.2':
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.3':
     optional: true
 
-  '@tauri-apps/cli-win32-ia32-msvc@2.11.2':
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.3':
     optional: true
 
-  '@tauri-apps/cli-win32-x64-msvc@2.11.2':
+  '@tauri-apps/cli-win32-x64-msvc@2.11.3':
     optional: true
 
-  '@tauri-apps/cli@2.11.2':
+  '@tauri-apps/cli@2.11.3':
     optionalDependencies:
-      '@tauri-apps/cli-darwin-arm64': 2.11.2
-      '@tauri-apps/cli-darwin-x64': 2.11.2
-      '@tauri-apps/cli-linux-arm-gnueabihf': 2.11.2
-      '@tauri-apps/cli-linux-arm64-gnu': 2.11.2
-      '@tauri-apps/cli-linux-arm64-musl': 2.11.2
-      '@tauri-apps/cli-linux-riscv64-gnu': 2.11.2
-      '@tauri-apps/cli-linux-x64-gnu': 2.11.2
-      '@tauri-apps/cli-linux-x64-musl': 2.11.2
-      '@tauri-apps/cli-win32-arm64-msvc': 2.11.2
-      '@tauri-apps/cli-win32-ia32-msvc': 2.11.2
-      '@tauri-apps/cli-win32-x64-msvc': 2.11.2
+      '@tauri-apps/cli-darwin-arm64': 2.11.3
+      '@tauri-apps/cli-darwin-x64': 2.11.3
+      '@tauri-apps/cli-linux-arm-gnueabihf': 2.11.3
+      '@tauri-apps/cli-linux-arm64-gnu': 2.11.3
+      '@tauri-apps/cli-linux-arm64-musl': 2.11.3
+      '@tauri-apps/cli-linux-riscv64-gnu': 2.11.3
+      '@tauri-apps/cli-linux-x64-gnu': 2.11.3
+      '@tauri-apps/cli-linux-x64-musl': 2.11.3
+      '@tauri-apps/cli-win32-arm64-msvc': 2.11.3
+      '@tauri-apps/cli-win32-ia32-msvc': 2.11.3
+      '@tauri-apps/cli-win32-x64-msvc': 2.11.3
 
   '@tauri-apps/plugin-store@2.4.3':
     dependencies:
@@ -536,14 +967,122 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/katex@0.16.8': {}
+
+  '@types/ms@2.1.0': {}
+
+  '@types/unist@2.0.11': {}
+
+  ansi-regex@6.2.2: {}
+
+  argparse@2.0.1: {}
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
+
+  commander@8.3.0: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  entities@4.5.0: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
 
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
   fsevents@2.3.3:
     optional: true
+
+  get-east-asian-width@1.6.0: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globby@16.2.0:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      fast-glob: 3.3.3
+      ignore: 7.0.5
+      is-path-inside: 4.0.0
+      slash: 5.1.0
+      unicorn-magic: 0.4.0
+
+  ignore@7.0.5: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
+
+  is-number@7.0.0: {}
+
+  is-path-inside@4.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  jsonc-parser@3.3.1: {}
+
+  jsonpointer@5.0.1: {}
+
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -594,17 +1133,263 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  nanoid@3.3.12: {}
+  linkify-it@5.0.1:
+    dependencies:
+      uc.micro: 2.1.0
+
+  markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.1
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  markdownlint-cli2-formatter-default@0.0.6(markdownlint-cli2@0.22.1):
+    dependencies:
+      markdownlint-cli2: 0.22.1
+
+  markdownlint-cli2@0.22.1:
+    dependencies:
+      globby: 16.2.0
+      js-yaml: 4.1.1
+      jsonc-parser: 3.3.1
+      jsonpointer: 5.0.1
+      markdown-it: 14.1.1
+      markdownlint: 0.40.0
+      markdownlint-cli2-formatter-default: 0.0.6(markdownlint-cli2@0.22.1)
+      micromatch: 4.0.8
+      smol-toml: 1.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  markdownlint@0.40.0:
+    dependencies:
+      micromark: 4.0.2
+      micromark-core-commonmark: 2.0.3
+      micromark-extension-directive: 4.0.0
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-math: 3.1.0
+      micromark-util-types: 2.0.2
+      string-width: 8.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdurl@2.0.0: {}
+
+  merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-directive@4.0.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      parse-entities: 4.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-math@3.1.0:
+    dependencies:
+      '@types/katex': 0.16.8
+      devlop: 1.1.0
+      katex: 0.16.47
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.13: {}
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
 
   picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
 
   postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.13
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  punycode.js@2.3.1: {}
+
+  queue-microtask@1.2.3: {}
+
+  reusify@1.1.0: {}
 
   rolldown@1.0.3:
     dependencies:
@@ -627,17 +1412,42 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.3
       '@rolldown/binding-win32-x64-msvc': 1.0.3
 
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  slash@5.1.0: {}
+
+  smol-toml@1.6.1: {}
+
   source-map-js@1.2.1: {}
+
+  string-width@8.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
   tslib@2.8.1:
     optional: true
 
   typescript@6.0.3: {}
+
+  uc.micro@2.1.0: {}
+
+  unicorn-magic@0.4.0: {}
 
   vite@8.0.16:
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "metermaid"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cpal",
  "ebur128",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metermaid"
-version = "0.1.0"
+version = "0.1.1"
 description = "MeterMaid — LUFS / loudness meter"
 authors = ["David Neal <david@reverentgeek.com>"]
 edition = "2021"

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -515,6 +515,22 @@ fn build_stream(
     let dev_name = device
         .name()
         .unwrap_or_else(|_| "the selected device".into());
+
+    // Debug-only: force a representative capture failure so the error UI can be
+    // exercised without unplugging hardware or revoking permissions. Run the dev
+    // app with `METERMAID_SIMULATE_ERROR=1` and press Start. Compiled out of
+    // release builds.
+    #[cfg(debug_assertions)]
+    if std::env::var_os("METERMAID_SIMULATE_ERROR").is_some() {
+        return Err(explain_build_error(
+            &dev_name,
+            cpal::BuildStreamError::BackendSpecific {
+                err: cpal::BackendSpecificError {
+                    description: "simulated failure (METERMAID_SIMULATE_ERROR)".into(),
+                },
+            },
+        ));
+    }
     let default = device
         .default_input_config()
         .map_err(|e| explain_default_config_error(&dev_name, e))?;

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -156,7 +156,10 @@ impl Analyzer {
         device_channels: usize,
     ) -> Result<(), String> {
         let ch = sel.len() as u32;
-        self.ebu = Some(EbuR128::new(ch, sample_rate, Mode::all()).map_err(|e| e.to_string())?);
+        self.ebu = Some(
+            EbuR128::new(ch, sample_rate, Mode::all())
+                .map_err(|e| format!("Couldn’t initialize the loudness analyzer: {e}"))?,
+        );
         self.sample_rate = sample_rate;
         self.channels = ch as u16;
         self.sel = sel;
@@ -347,17 +350,99 @@ fn validate_selection(sel: &[usize], device_channels: usize) -> Result<(), Strin
     Ok(())
 }
 
+/// Platform-specific guidance appended to capture failures that are commonly
+/// caused by the OS withholding microphone access (the usual reason a build or
+/// start fails with an opaque backend error). Kept actionable: it names the
+/// exact place to grant access so the user can fix it without guessing.
+fn mic_permission_hint() -> &'static str {
+    if cfg!(target_os = "macos") {
+        " If this is the first time starting capture, macOS may be blocking \
+microphone access — open System Settings → Privacy & Security → Microphone, \
+enable MeterMaid, then try again."
+    } else if cfg!(target_os = "windows") {
+        " Windows may be blocking microphone access — open Settings → Privacy & \
+security → Microphone, allow desktop apps to access the microphone, then try \
+again."
+    } else {
+        " Your system may be blocking microphone access, or another application \
+may be using the device exclusively."
+    }
+}
+
+/// Map a cpal `DefaultStreamConfigError` (raised while reading a device's
+/// capabilities) to an actionable message naming the device.
+fn explain_default_config_error(device: &str, err: cpal::DefaultStreamConfigError) -> String {
+    use cpal::DefaultStreamConfigError::*;
+    match err {
+        DeviceNotAvailable => {
+            format!("“{device}” is no longer available. Reconnect it or pick another input device.")
+        }
+        StreamTypeNotSupported => {
+            format!("“{device}” doesn’t expose a capture format MeterMaid can read.")
+        }
+        other => format!(
+            "Couldn’t read the audio settings for “{device}”: {other}.{}",
+            mic_permission_hint()
+        ),
+    }
+}
+
+/// Map a cpal `BuildStreamError` (raised while opening the capture stream) to an
+/// actionable message. Backend-specific failures — where a denied microphone
+/// permission usually lands — carry the permission hint.
+fn explain_build_error(device: &str, err: cpal::BuildStreamError) -> String {
+    use cpal::BuildStreamError::*;
+    match err {
+        DeviceNotAvailable => {
+            format!("“{device}” is no longer available. Reconnect it or pick another input device.")
+        }
+        StreamConfigNotSupported => format!(
+            "“{device}” doesn’t support the selected sample rate or channels. \
+Try a different sample rate."
+        ),
+        InvalidArgument => format!(
+            "MeterMaid requested invalid capture settings for “{device}”. \
+Try a different channel or sample-rate selection."
+        ),
+        other => format!(
+            "Couldn’t open “{device}” for capture: {other}.{}",
+            mic_permission_hint()
+        ),
+    }
+}
+
+/// Map a cpal `PlayStreamError` (raised while starting the built stream) to an
+/// actionable message.
+fn explain_play_error(device: &str, err: cpal::PlayStreamError) -> String {
+    use cpal::PlayStreamError::*;
+    match err {
+        DeviceNotAvailable => {
+            format!("“{device}” is no longer available. Reconnect it or pick another input device.")
+        }
+        other => format!(
+            "Couldn’t start capture on “{device}”: {other}.{}",
+            mic_permission_hint()
+        ),
+    }
+}
+
 fn find_device(name: &Option<String>) -> Result<cpal::Device, String> {
     let host = cpal::default_host();
     match name {
         Some(name) => host
             .input_devices()
-            .map_err(|e| e.to_string())?
+            .map_err(|e| format!("Couldn’t list input devices: {e}"))?
             .find(|d| d.name().map(|n| &n == name).unwrap_or(false))
-            .ok_or_else(|| format!("input device not found: {name}")),
-        None => host
-            .default_input_device()
-            .ok_or_else(|| "no default input device".to_string()),
+            .ok_or_else(|| {
+                format!(
+                    "Input device “{name}” wasn’t found. It may have been disconnected — \
+pick another device from the list."
+                )
+            }),
+        None => host.default_input_device().ok_or_else(|| {
+            "No input device found. Connect a microphone or audio interface and try again."
+                .to_string()
+        }),
     }
 }
 
@@ -376,7 +461,12 @@ pub fn list_input_devices() -> Result<Vec<DeviceInfo>, String> {
 
 pub fn device_config(name: Option<String>) -> Result<DeviceConfig, String> {
     let device = find_device(&name)?;
-    let default = device.default_input_config().map_err(|e| e.to_string())?;
+    let dev_name = device
+        .name()
+        .unwrap_or_else(|_| "the selected device".into());
+    let default = device
+        .default_input_config()
+        .map_err(|e| explain_default_config_error(&dev_name, e))?;
     let channels = default.channels();
     let default_sample_rate = default.sample_rate().0;
 
@@ -422,8 +512,12 @@ fn build_stream(
     sel: Vec<u32>,
 ) -> Result<BuiltStream, String> {
     let device = find_device(&device_name)?;
-    let dev_name = device.name().unwrap_or_else(|_| "unknown".into());
-    let default = device.default_input_config().map_err(|e| e.to_string())?;
+    let dev_name = device
+        .name()
+        .unwrap_or_else(|_| "the selected device".into());
+    let default = device
+        .default_input_config()
+        .map_err(|e| explain_default_config_error(&dev_name, e))?;
     let device_channels = default.channels();
     let sample_format = default.sample_format();
     let rate = sample_rate.unwrap_or_else(|| default.sample_rate().0);
@@ -508,9 +602,13 @@ fn build_stream(
                 None,
             )
         }
-        other => return Err(format!("unsupported sample format: {other:?}")),
+        other => {
+            return Err(format!(
+                "“{dev_name}” uses an audio format MeterMaid can’t read ({other:?})."
+            ))
+        }
     }
-    .map_err(|e| e.to_string())?;
+    .map_err(|e| explain_build_error(&dev_name, e))?;
 
     Ok(BuiltStream {
         stream,
@@ -561,6 +659,7 @@ pub fn engine_loop(rx: Receiver<Command>, app: AppHandle) {
                 active = None; // stop any existing stream first
                 match build_stream(&app, device, sample_rate, channels) {
                     Ok(built) => {
+                        let dev_name = built.info.device_name.clone();
                         if let Err(e) =
                             analyzer.configure(built.sample_rate, built.sel, built.device_channels)
                         {
@@ -578,7 +677,7 @@ pub fn engine_loop(rx: Receiver<Command>, app: AppHandle) {
                             }
                             Err(e) => {
                                 analyzer.shutdown();
-                                let _ = reply.send(Err(e.to_string()));
+                                let _ = reply.send(Err(explain_play_error(&dev_name, e)));
                             }
                         }
                     }
@@ -669,6 +768,46 @@ mod tests {
         assert_eq!(clean(None, LOUDNESS_FLOOR), LOUDNESS_FLOOR);
         // Finite-but-below-floor values are clamped up to the floor.
         assert_eq!(clean(Some(-100.0), LOUDNESS_FLOOR), LOUDNESS_FLOOR);
+    }
+
+    // --- Error messages -----------------------------------------------------
+
+    #[test]
+    fn build_error_messages_name_the_device_and_are_actionable() {
+        // A vanished device tells the user to reconnect or pick another.
+        let msg = explain_build_error("Scarlett 2i2", cpal::BuildStreamError::DeviceNotAvailable);
+        assert!(msg.contains("Scarlett 2i2"), "got: {msg}");
+        assert!(msg.contains("no longer available"), "got: {msg}");
+
+        // An unsupported config points at the sample rate.
+        let msg = explain_build_error(
+            "Built-in Mic",
+            cpal::BuildStreamError::StreamConfigNotSupported,
+        );
+        assert!(msg.contains("sample rate"), "got: {msg}");
+
+        // Backend-specific failures (where denied mic permission lands) carry
+        // the permission hint.
+        let backend = cpal::BuildStreamError::BackendSpecific {
+            err: cpal::BackendSpecificError {
+                description: "kAudioUnitErr_NoConnection".into(),
+            },
+        };
+        let msg = explain_build_error("Built-in Mic", backend);
+        assert!(msg.contains("Built-in Mic"), "got: {msg}");
+        assert!(msg.to_lowercase().contains("microphone"), "got: {msg}");
+    }
+
+    #[test]
+    fn play_error_carries_permission_hint() {
+        let backend = cpal::PlayStreamError::BackendSpecific {
+            err: cpal::BackendSpecificError {
+                description: "denied".into(),
+            },
+        };
+        let msg = explain_play_error("Mic", backend);
+        assert!(msg.contains("Mic"), "got: {msg}");
+        assert!(msg.to_lowercase().contains("microphone"), "got: {msg}");
     }
 
     // --- Channel selection / de-interleave ---------------------------------

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeterMaid",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.davidneal.metermaid",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,6 +65,10 @@ const deltaEl = $<HTMLDivElement>("delta");
 const tpCard = $<HTMLDivElement>("tpCard");
 const clipFlag = $<HTMLSpanElement>("clipFlag");
 const autostartInput = $<HTMLInputElement>("autostart");
+const errorBanner = $<HTMLDivElement>("errorBanner");
+const errorMessage = $<HTMLSpanElement>("errorMessage");
+const errorCopy = $<HTMLButtonElement>("errorCopy");
+const errorDismiss = $<HTMLButtonElement>("errorDismiss");
 const canvas = $<HTMLCanvasElement>("spectrum");
 const ctx = canvas.getContext("2d")!;
 
@@ -113,6 +117,41 @@ function setStatus(text: string, kind: "ok" | "err" | "idle") {
   statusEl.className = `status status-${kind}`;
 }
 
+// Tauri command rejections are usually plain strings (our Rust commands return
+// `Result<_, String>`), but normalize anything else so the user never sees an
+// unhelpful "[object Object]".
+function errText(e: unknown): string {
+  if (typeof e === "string") return e;
+  if (e instanceof Error) return e.message;
+  if (e && typeof e === "object") {
+    const msg = (e as { message?: unknown }).message;
+    if (typeof msg === "string") return msg;
+    try {
+      return JSON.stringify(e);
+    } catch {
+      /* fall through to String() */
+    }
+  }
+  return String(e);
+}
+
+function hideError() {
+  errorBanner.hidden = true;
+  errorMessage.textContent = "";
+}
+
+// Surface a failure the user can actually read, copy, and report. `context` is
+// a short label for what was attempted ("Start capture"); the toolbar status
+// stays terse while the banner shows the full, selectable detail. Also logs to
+// the console so it's recoverable from a dev build / webview inspector.
+function reportError(context: string, e: unknown) {
+  const detail = errText(e);
+  console.error(`${context}:`, e);
+  setStatus("error", "err");
+  errorMessage.textContent = `${context}: ${detail}`;
+  errorBanner.hidden = false;
+}
+
 function configControlsEnabled(enabled: boolean) {
   deviceSelect.disabled = !enabled;
   channelSelect.disabled = !enabled;
@@ -154,7 +193,7 @@ async function loadDevices() {
     }
     await refreshDeviceConfig();
   } catch (e) {
-    setStatus(String(e), "err");
+    reportError("List input devices", e);
   }
 }
 
@@ -212,7 +251,7 @@ async function refreshDeviceConfig() {
       pendingRate = undefined;
     }
   } catch (e) {
-    setStatus(String(e), "err");
+    reportError("Read device settings", e);
   }
 }
 
@@ -236,8 +275,9 @@ async function start() {
     configControlsEnabled(false);
     const mode = info.channels === 1 ? "mono" : `${info.channels} ch`;
     setStatus(`${info.sampleRate / 1000} kHz · ${mode}`, "ok");
+    hideError();
   } catch (e) {
-    setStatus(String(e), "err");
+    reportError("Start capture", e);
   }
 }
 
@@ -255,7 +295,7 @@ async function stop() {
   try {
     await invoke("stop_capture");
   } catch (e) {
-    setStatus(String(e), "err");
+    reportError("Stop capture", e);
   }
   teardownRunningUi();
   setStatus("stopped", "idle");
@@ -267,7 +307,7 @@ function handleStreamError(message: string) {
   if (!running) return;
   void invoke("stop_capture").catch(() => {});
   teardownRunningUi();
-  setStatus(`device error: ${message}`, "err");
+  reportError("Audio device", message);
 }
 
 function updateReadouts(m: Metrics) {
@@ -466,7 +506,7 @@ function resetMeasurement() {
   clipLatched = false;
   tpCard.classList.remove("clipping");
   clipFlag.classList.remove("on");
-  invoke("reset_integrated").catch((e) => setStatus(String(e), "err"));
+  invoke("reset_integrated").catch((e) => reportError("Reset measurement", e));
 }
 
 window.addEventListener("DOMContentLoaded", async () => {
@@ -505,6 +545,16 @@ window.addEventListener("DOMContentLoaded", async () => {
   });
   toggleBtn.addEventListener("click", () => (running ? stop() : start()));
   resetBtn.addEventListener("click", resetMeasurement);
+  errorDismiss.addEventListener("click", hideError);
+  errorCopy.addEventListener("click", async () => {
+    try {
+      await navigator.clipboard.writeText(errorMessage.textContent ?? "");
+      errorCopy.textContent = "Copied";
+      setTimeout(() => (errorCopy.textContent = "Copy"), 1500);
+    } catch {
+      // Clipboard unavailable — the message is selectable in the banner.
+    }
+  });
   channelSelect.addEventListener("change", () => void persist());
   rateSelect.addEventListener("change", () => void persist());
   autostartInput.addEventListener("change", () => void persist());

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,34 +1,42 @@
+// Bundled fonts (Latin subset) so the UI looks identical on macOS, Windows, and
+// Linux instead of falling back to each OS's default sans/mono. Inter for the
+// chrome, JetBrains Mono for the numeric readouts and spectrum labels.
+import "@fontsource/inter/latin-400.css";
+import "@fontsource/inter/latin-600.css";
+import "@fontsource/inter/latin-700.css";
+import "@fontsource/jetbrains-mono/latin-400.css";
+import "@fontsource/jetbrains-mono/latin-600.css";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { load, type Store } from "@tauri-apps/plugin-store";
 
 interface DeviceInfo {
-  name: string;
-  isDefault: boolean;
+	name: string;
+	isDefault: boolean;
 }
 
 interface DeviceConfig {
-  channels: number;
-  defaultSampleRate: number;
-  sampleRates: number[];
+	channels: number;
+	defaultSampleRate: number;
+	sampleRates: number[];
 }
 
 interface StreamInfo {
-  deviceName: string;
-  sampleRate: number;
-  channels: number;
+	deviceName: string;
+	sampleRate: number;
+	channels: number;
 }
 
 interface Metrics {
-  momentary: number;
-  shortTerm: number;
-  integrated: number;
-  lra: number;
-  truePeakDb: number;
-  truePeakMaxDb: number;
-  spectrum: number[];
-  sampleRate: number;
-  channels: number;
+	momentary: number;
+	shortTerm: number;
+	integrated: number;
+	lra: number;
+	truePeakDb: number;
+	truePeakMaxDb: number;
+	spectrum: number[];
+	sampleRate: number;
+	channels: number;
 }
 
 const LOUDNESS_FLOOR = -70;
@@ -51,13 +59,15 @@ let lastPeakTs = 0; // timestamp of the last true-peak ballistics update (ms)
 let lastFrameTs = 0; // timestamp of the last spectrum frame (ms)
 let clipLatched = false;
 
-const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
+const $ = <T extends HTMLElement>(id: string) =>
+	document.getElementById(id) as T;
 
 const deviceSelect = $<HTMLSelectElement>("device");
 const channelSelect = $<HTMLSelectElement>("channels");
 const rateSelect = $<HTMLSelectElement>("rate");
-const toggleBtn = $<HTMLButtonElement>("toggle");
+const startBtn = $<HTMLButtonElement>("start");
 const resetBtn = $<HTMLButtonElement>("reset");
+const stopBtn = $<HTMLButtonElement>("stop");
 const statusEl = $<HTMLSpanElement>("status");
 const targetInput = $<HTMLInputElement>("target");
 const ceilingInput = $<HTMLInputElement>("ceiling");
@@ -69,6 +79,8 @@ const errorBanner = $<HTMLDivElement>("errorBanner");
 const errorMessage = $<HTMLSpanElement>("errorMessage");
 const errorCopy = $<HTMLButtonElement>("errorCopy");
 const errorDismiss = $<HTMLButtonElement>("errorDismiss");
+const resetHint = $<HTMLDivElement>("resetHint");
+const hintDismiss = $<HTMLButtonElement>("hintDismiss");
 const canvas = $<HTMLCanvasElement>("spectrum");
 const ctx = canvas.getContext("2d")!;
 
@@ -86,58 +98,64 @@ let pendingChannels: string | undefined;
 let pendingRate: number | undefined;
 // Whether the saved device is actually present this launch (gates auto-start).
 let savedDeviceAvailable = true;
+// One-time onboarding: show the "Reset between patches" hint until the user has
+// seen it once (dismissed it or used Reset). Persisted so it never nags again.
+let resetHintSeen = false;
 
 const numOrNull = (s: string) => {
-  const n = parseFloat(s);
-  return Number.isFinite(n) ? n : null;
+	const n = parseFloat(s);
+	return Number.isFinite(n) ? n : null;
 };
 
 async function persist() {
-  if (!store || restoring) return;
-  try {
-    await store.set("device", deviceSelect.value || "");
-    await store.set("channels", channelSelect.value);
-    await store.set("sampleRate", rateSelect.value ? Number(rateSelect.value) : null);
-    await store.set("target", numOrNull(targetInput.value));
-    await store.set("ceiling", numOrNull(ceilingInput.value));
-    await store.set("autoStart", autostartInput.checked);
-    await store.save();
-  } catch {
-    // Persistence is best-effort; never block metering on a failed write.
-  }
+	if (!store || restoring) return;
+	try {
+		await store.set("device", deviceSelect.value || "");
+		await store.set("channels", channelSelect.value);
+		await store.set(
+			"sampleRate",
+			rateSelect.value ? Number(rateSelect.value) : null,
+		);
+		await store.set("target", numOrNull(targetInput.value));
+		await store.set("ceiling", numOrNull(ceilingInput.value));
+		await store.set("autoStart", autostartInput.checked);
+		await store.save();
+	} catch {
+		// Persistence is best-effort; never block metering on a failed write.
+	}
 }
 
 function fmt(v: number, floor = LOUDNESS_FLOOR): string {
-  if (!Number.isFinite(v) || v <= floor) return "−∞";
-  return v.toFixed(1);
+	if (!Number.isFinite(v) || v <= floor) return "−∞";
+	return v.toFixed(1);
 }
 
 function setStatus(text: string, kind: "ok" | "err" | "idle") {
-  statusEl.textContent = text;
-  statusEl.className = `status status-${kind}`;
+	statusEl.textContent = text;
+	statusEl.className = `status status-${kind}`;
 }
 
 // Tauri command rejections are usually plain strings (our Rust commands return
 // `Result<_, String>`), but normalize anything else so the user never sees an
 // unhelpful "[object Object]".
 function errText(e: unknown): string {
-  if (typeof e === "string") return e;
-  if (e instanceof Error) return e.message;
-  if (e && typeof e === "object") {
-    const msg = (e as { message?: unknown }).message;
-    if (typeof msg === "string") return msg;
-    try {
-      return JSON.stringify(e);
-    } catch {
-      /* fall through to String() */
-    }
-  }
-  return String(e);
+	if (typeof e === "string") return e;
+	if (e instanceof Error) return e.message;
+	if (e && typeof e === "object") {
+		const msg = (e as { message?: unknown }).message;
+		if (typeof msg === "string") return msg;
+		try {
+			return JSON.stringify(e);
+		} catch {
+			/* fall through to String() */
+		}
+	}
+	return String(e);
 }
 
 function hideError() {
-  errorBanner.hidden = true;
-  errorMessage.textContent = "";
+	errorBanner.hidden = true;
+	errorMessage.textContent = "";
 }
 
 // Surface a failure the user can actually read, copy, and report. `context` is
@@ -145,255 +163,287 @@ function hideError() {
 // stays terse while the banner shows the full, selectable detail. Also logs to
 // the console so it's recoverable from a dev build / webview inspector.
 function reportError(context: string, e: unknown) {
-  const detail = errText(e);
-  console.error(`${context}:`, e);
-  setStatus("error", "err");
-  errorMessage.textContent = `${context}: ${detail}`;
-  errorBanner.hidden = false;
+	const detail = errText(e);
+	console.error(`${context}:`, e);
+	setStatus("error", "err");
+	errorMessage.textContent = `${context}: ${detail}`;
+	errorBanner.hidden = false;
 }
 
 function configControlsEnabled(enabled: boolean) {
-  deviceSelect.disabled = !enabled;
-  channelSelect.disabled = !enabled;
-  rateSelect.disabled = !enabled;
+	deviceSelect.disabled = !enabled;
+	channelSelect.disabled = !enabled;
+	rateSelect.disabled = !enabled;
 }
 
 async function loadDevices() {
-  try {
-    const devices = await invoke<DeviceInfo[]>("list_devices");
-    deviceSelect.innerHTML = "";
-    if (devices.length === 0) {
-      const opt = document.createElement("option");
-      opt.textContent = "No input devices found";
-      opt.disabled = true;
-      deviceSelect.append(opt);
-      return;
-    }
-    for (const d of devices) {
-      const opt = document.createElement("option");
-      opt.value = d.name;
-      opt.textContent = d.isDefault ? `${d.name} (default)` : d.name;
-      if (d.isDefault) opt.selected = true;
-      deviceSelect.append(opt);
-    }
-    // Restore the saved device if it's still present; otherwise leave the
-    // system default selected and surface a notice. When the saved device is
-    // gone we also drop the saved channels/rate so the default device gets its
-    // own sensible defaults rather than a mismatched selection.
-    if (pendingDevice) {
-      if (devices.some((d) => d.name === pendingDevice)) {
-        deviceSelect.value = pendingDevice;
-      } else {
-        savedDeviceAvailable = false;
-        pendingChannels = undefined;
-        pendingRate = undefined;
-        setStatus("saved device unavailable — using default", "err");
-      }
-      pendingDevice = undefined;
-    }
-    await refreshDeviceConfig();
-  } catch (e) {
-    reportError("List input devices", e);
-  }
+	try {
+		const devices = await invoke<DeviceInfo[]>("list_devices");
+		deviceSelect.innerHTML = "";
+		if (devices.length === 0) {
+			const opt = document.createElement("option");
+			opt.textContent = "No input devices found";
+			opt.disabled = true;
+			deviceSelect.append(opt);
+			return;
+		}
+		for (const d of devices) {
+			const opt = document.createElement("option");
+			opt.value = d.name;
+			opt.textContent = d.isDefault ? `${d.name} (default)` : d.name;
+			if (d.isDefault) opt.selected = true;
+			deviceSelect.append(opt);
+		}
+		// Restore the saved device if it's still present; otherwise leave the
+		// system default selected and surface a notice. When the saved device is
+		// gone we also drop the saved channels/rate so the default device gets its
+		// own sensible defaults rather than a mismatched selection.
+		if (pendingDevice) {
+			if (devices.some((d) => d.name === pendingDevice)) {
+				deviceSelect.value = pendingDevice;
+			} else {
+				savedDeviceAvailable = false;
+				pendingChannels = undefined;
+				pendingRate = undefined;
+				setStatus("saved device unavailable — using default", "err");
+			}
+			pendingDevice = undefined;
+		}
+		await refreshDeviceConfig();
+	} catch (e) {
+		reportError("List input devices", e);
+	}
 }
 
 // Build generic channel options: stereo pairs first, then mono channels.
 function populateChannels(count: number) {
-  channelSelect.innerHTML = "";
-  const add = (label: string, indices: number[]) => {
-    const opt = document.createElement("option");
-    opt.value = indices.join(",");
-    opt.textContent = label;
-    channelSelect.append(opt);
-  };
-  for (let i = 0; i + 1 < count; i += 2) {
-    add(`Ch ${i + 1}–${i + 2}`, [i, i + 1]);
-  }
-  for (let i = 0; i < count; i++) {
-    add(`Ch ${i + 1} (mono)`, [i]);
-  }
-  if (count === 0) add("No channels", []);
-  channelSelect.selectedIndex = 0; // first stereo pair (Ch 1–2) when available
+	channelSelect.innerHTML = "";
+	const add = (label: string, indices: number[]) => {
+		const opt = document.createElement("option");
+		opt.value = indices.join(",");
+		opt.textContent = label;
+		channelSelect.append(opt);
+	};
+	for (let i = 0; i + 1 < count; i += 2) {
+		add(`Ch ${i + 1}–${i + 2}`, [i, i + 1]);
+	}
+	for (let i = 0; i < count; i++) {
+		add(`Ch ${i + 1} (mono)`, [i]);
+	}
+	if (count === 0) add("No channels", []);
+	channelSelect.selectedIndex = 0; // first stereo pair (Ch 1–2) when available
 }
 
 function populateRates(rates: number[], def: number) {
-  rateSelect.innerHTML = "";
-  for (const r of rates) {
-    const opt = document.createElement("option");
-    opt.value = String(r);
-    opt.textContent = `${r / 1000} kHz`;
-    if (r === def) opt.selected = true;
-    rateSelect.append(opt);
-  }
+	rateSelect.innerHTML = "";
+	for (const r of rates) {
+		const opt = document.createElement("option");
+		opt.value = String(r);
+		opt.textContent = `${r / 1000} kHz`;
+		if (r === def) opt.selected = true;
+		rateSelect.append(opt);
+	}
 }
 
 async function refreshDeviceConfig() {
-  try {
-    const cfg = await invoke<DeviceConfig>("get_device_config", {
-      device: deviceSelect.value || null,
-    });
-    populateChannels(cfg.channels);
-    populateRates(cfg.sampleRates, cfg.defaultSampleRate);
+	try {
+		const cfg = await invoke<DeviceConfig>("get_device_config", {
+			device: deviceSelect.value || null,
+		});
+		populateChannels(cfg.channels);
+		populateRates(cfg.sampleRates, cfg.defaultSampleRate);
 
-    // Reapply saved channel/rate selections, but only if they're still valid
-    // for this device — otherwise the defaults chosen above stand. Consumed
-    // once: subsequent device switches fall through to plain defaults.
-    if (pendingChannels !== undefined) {
-      if (Array.from(channelSelect.options).some((o) => o.value === pendingChannels)) {
-        channelSelect.value = pendingChannels;
-      }
-      pendingChannels = undefined;
-    }
-    if (pendingRate !== undefined) {
-      if (cfg.sampleRates.includes(pendingRate)) {
-        rateSelect.value = String(pendingRate);
-      }
-      pendingRate = undefined;
-    }
-  } catch (e) {
-    reportError("Read device settings", e);
-  }
+		// Reapply saved channel/rate selections, but only if they're still valid
+		// for this device — otherwise the defaults chosen above stand. Consumed
+		// once: subsequent device switches fall through to plain defaults.
+		if (pendingChannels !== undefined) {
+			if (
+				Array.from(channelSelect.options).some(
+					(o) => o.value === pendingChannels,
+				)
+			) {
+				channelSelect.value = pendingChannels;
+			}
+			pendingChannels = undefined;
+		}
+		if (pendingRate !== undefined) {
+			if (cfg.sampleRates.includes(pendingRate)) {
+				rateSelect.value = String(pendingRate);
+			}
+			pendingRate = undefined;
+		}
+	} catch (e) {
+		reportError("Read device settings", e);
+	}
 }
 
 async function start() {
-  try {
-    const channels = channelSelect.value
-      ? channelSelect.value.split(",").map(Number)
-      : [];
-    const sampleRate = rateSelect.value ? Number(rateSelect.value) : null;
-    const info = await invoke<StreamInfo>("start_capture", {
-      device: deviceSelect.value || null,
-      sampleRate,
-      channels,
-    });
-    running = true;
-    clipLatched = false;
-    displayedPeak = PEAK_FLOOR;
-    lastPeakTs = 0;
-    toggleBtn.textContent = "Stop";
-    toggleBtn.classList.add("running");
-    configControlsEnabled(false);
-    const mode = info.channels === 1 ? "mono" : `${info.channels} ch`;
-    setStatus(`${info.sampleRate / 1000} kHz · ${mode}`, "ok");
-    hideError();
-  } catch (e) {
-    reportError("Start capture", e);
-  }
+	try {
+		const channels = channelSelect.value
+			? channelSelect.value.split(",").map(Number)
+			: [];
+		const sampleRate = rateSelect.value ? Number(rateSelect.value) : null;
+		const info = await invoke<StreamInfo>("start_capture", {
+			device: deviceSelect.value || null,
+			sampleRate,
+			channels,
+		});
+		running = true;
+		clipLatched = false;
+		displayedPeak = PEAK_FLOOR;
+		lastPeakTs = 0;
+		// Reset becomes the in-session primary; Stop is a quiet secondary.
+		startBtn.hidden = true;
+		resetBtn.hidden = false;
+		stopBtn.hidden = false;
+		configControlsEnabled(false);
+		const mode = info.channels === 1 ? "mono" : `${info.channels} ch`;
+		setStatus(`${info.sampleRate / 1000} kHz · ${mode}`, "ok");
+		hideError();
+		maybeShowResetHint();
+	} catch (e) {
+		reportError("Start capture", e);
+	}
+}
+
+// Show the "Reset between patches" hint once, the first time capture starts.
+function maybeShowResetHint() {
+	if (!resetHintSeen) resetHint.hidden = false;
+}
+
+// Hide the hint and remember it's been seen, so it never shows again. Called
+// when the user dismisses it or uses Reset for the first time.
+async function markResetHintSeen() {
+	resetHint.hidden = true;
+	if (resetHintSeen) return;
+	resetHintSeen = true;
+	if (!store) return;
+	try {
+		await store.set("resetHintSeen", true);
+		await store.save();
+	} catch {
+		// Best-effort; the hint reappearing next session is harmless.
+	}
 }
 
 // Return the UI to its idle/stopped state. Shared by an explicit Stop and by
 // involuntary teardown when the capture device faults.
 function teardownRunningUi() {
-  running = false;
-  latest = null;
-  toggleBtn.textContent = "Start";
-  toggleBtn.classList.remove("running");
-  configControlsEnabled(true);
+	running = false;
+	latest = null;
+	startBtn.hidden = false;
+	resetBtn.hidden = true;
+	stopBtn.hidden = true;
+	// Tuck the hint away with the session; seen-state is untouched so a user who
+	// never engaged still gets it next time.
+	resetHint.hidden = true;
+	configControlsEnabled(true);
 }
 
 async function stop() {
-  try {
-    await invoke("stop_capture");
-  } catch (e) {
-    reportError("Stop capture", e);
-  }
-  teardownRunningUi();
-  setStatus("stopped", "idle");
+	try {
+		await invoke("stop_capture");
+	} catch (e) {
+		reportError("Stop capture", e);
+	}
+	teardownRunningUi();
+	setStatus("stopped", "idle");
 }
 
 // The audio engine emits this when the OS reports a fault on the active stream
 // (e.g. the device is unplugged mid-capture). Tear down and surface why.
 function handleStreamError(message: string) {
-  if (!running) return;
-  void invoke("stop_capture").catch(() => {});
-  teardownRunningUi();
-  reportError("Audio device", message);
+	if (!running) return;
+	void invoke("stop_capture").catch(() => {});
+	teardownRunningUi();
+	reportError("Audio device", message);
 }
 
 function updateReadouts(m: Metrics) {
-  $("integrated").textContent = fmt(m.integrated);
-  $("shortTerm").textContent = fmt(m.shortTerm);
-  $("momentary").textContent = fmt(m.momentary);
-  $("lra").textContent = m.lra > 0 ? m.lra.toFixed(1) : "0.0";
+	$("integrated").textContent = fmt(m.integrated);
+	$("shortTerm").textContent = fmt(m.shortTerm);
+	$("momentary").textContent = fmt(m.momentary);
+	$("lra").textContent = m.lra > 0 ? m.lra.toFixed(1) : "0.0";
 
-  // Live true peak with release ballistics; held max from the engine.
-  const now = performance.now();
-  const dt = lastPeakTs ? Math.min((now - lastPeakTs) / 1000, MAX_TICK_SEC) : 0;
-  lastPeakTs = now;
-  const live = m.truePeakDb;
-  displayedPeak =
-    live > displayedPeak
-      ? live
-      : Math.max(live, displayedPeak - PEAK_RELEASE_DB_PER_SEC * dt);
-  $("truePeak").textContent = fmt(displayedPeak, PEAK_FLOOR);
-  $("truePeakMax").textContent = fmt(m.truePeakMaxDb, PEAK_FLOOR);
+	// Live true peak with release ballistics; held max from the engine.
+	const now = performance.now();
+	const dt = lastPeakTs ? Math.min((now - lastPeakTs) / 1000, MAX_TICK_SEC) : 0;
+	lastPeakTs = now;
+	const live = m.truePeakDb;
+	displayedPeak =
+		live > displayedPeak
+			? live
+			: Math.max(live, displayedPeak - PEAK_RELEASE_DB_PER_SEC * dt);
+	$("truePeak").textContent = fmt(displayedPeak, PEAK_FLOOR);
+	$("truePeakMax").textContent = fmt(m.truePeakMaxDb, PEAK_FLOOR);
 
-  // Clip indicator latches once the held max crosses the ceiling.
-  const ceiling = parseFloat(ceilingInput.value);
-  if (Number.isFinite(ceiling) && m.truePeakMaxDb >= ceiling) clipLatched = true;
-  tpCard.classList.toggle("clipping", clipLatched);
-  clipFlag.classList.toggle("on", clipLatched);
+	// Clip indicator latches once the held max crosses the ceiling.
+	const ceiling = parseFloat(ceilingInput.value);
+	if (Number.isFinite(ceiling) && m.truePeakMaxDb >= ceiling)
+		clipLatched = true;
+	tpCard.classList.toggle("clipping", clipLatched);
+	clipFlag.classList.toggle("on", clipLatched);
 
-  const target = parseFloat(targetInput.value);
-  if (Number.isFinite(target) && m.integrated > LOUDNESS_FLOOR) {
-    const gain = target - m.integrated;
-    const sign = gain >= 0 ? "+" : "−";
-    deltaEl.innerHTML = `<span class="delta-label">apply</span> <strong>${sign}${Math.abs(gain).toFixed(1)} dB</strong>`;
-    deltaEl.classList.toggle("hot", Math.abs(gain) > 1);
-  } else {
-    deltaEl.innerHTML = `<span class="delta-label">apply</span> <strong>—</strong>`;
-    deltaEl.classList.remove("hot");
-  }
+	const target = parseFloat(targetInput.value);
+	if (Number.isFinite(target) && m.integrated > LOUDNESS_FLOOR) {
+		const gain = target - m.integrated;
+		const sign = gain >= 0 ? "+" : "−";
+		deltaEl.innerHTML = `<span class="delta-label">apply</span> <strong>${sign}${Math.abs(gain).toFixed(1)} dB</strong>`;
+		deltaEl.classList.toggle("hot", Math.abs(gain) > 1);
+	} else {
+		deltaEl.innerHTML = `<span class="delta-label">apply</span> <strong>—</strong>`;
+		deltaEl.classList.remove("hot");
+	}
 }
 
 function resizeCanvas() {
-  const dpr = window.devicePixelRatio || 1;
-  const rect = canvas.getBoundingClientRect();
-  canvas.width = Math.max(1, Math.round(rect.width * dpr));
-  canvas.height = Math.max(1, Math.round(rect.height * dpr));
-  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+	const dpr = window.devicePixelRatio || 1;
+	const rect = canvas.getBoundingClientRect();
+	canvas.width = Math.max(1, Math.round(rect.width * dpr));
+	canvas.height = Math.max(1, Math.round(rect.height * dpr));
+	ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 }
 
 // Reference grid lines at musically useful frequencies. `major` ticks get a
 // brighter line plus a text label; the rest are faint, unlabeled minor ticks
 // that help pinpoint which frequency is spiking without cluttering the axis.
 const GRID_HZ: { hz: number; major: boolean }[] = [
-  { hz: 20, major: true },
-  { hz: 30, major: false },
-  { hz: 40, major: false },
-  { hz: 50, major: true },
-  { hz: 60, major: false },
-  { hz: 80, major: false },
-  { hz: 100, major: true },
-  { hz: 150, major: false },
-  { hz: 200, major: true },
-  { hz: 300, major: false },
-  { hz: 400, major: false },
-  { hz: 500, major: true },
-  { hz: 700, major: false },
-  { hz: 1000, major: true },
-  { hz: 1500, major: false },
-  { hz: 2000, major: true },
-  { hz: 3000, major: false },
-  { hz: 4000, major: false },
-  { hz: 5000, major: true },
-  { hz: 7000, major: false },
-  { hz: 10000, major: true },
-  { hz: 15000, major: true },
-  { hz: 20000, major: true },
+	{ hz: 20, major: true },
+	{ hz: 30, major: false },
+	{ hz: 40, major: false },
+	{ hz: 50, major: true },
+	{ hz: 60, major: false },
+	{ hz: 80, major: false },
+	{ hz: 100, major: true },
+	{ hz: 150, major: false },
+	{ hz: 200, major: true },
+	{ hz: 300, major: false },
+	{ hz: 400, major: false },
+	{ hz: 500, major: true },
+	{ hz: 700, major: false },
+	{ hz: 1000, major: true },
+	{ hz: 1500, major: false },
+	{ hz: 2000, major: true },
+	{ hz: 3000, major: false },
+	{ hz: 4000, major: false },
+	{ hz: 5000, major: true },
+	{ hz: 7000, major: false },
+	{ hz: 10000, major: true },
+	{ hz: 15000, major: true },
+	{ hz: 20000, major: true },
 ];
 
 function fmtHz(hz: number): string {
-  if (hz < 1000) return `${hz}`;
-  const k = hz / 1000;
-  return `${Number.isInteger(k) ? k : k.toFixed(1)}k`;
+	if (hz < 1000) return `${hz}`;
+	const k = hz / 1000;
+	return `${Number.isInteger(k) ? k : k.toFixed(1)}k`;
 }
 
 function hzToX(hz: number, w: number, nyquist: number): number {
-  const fLo = 20;
-  const fHi = Math.min(20000, nyquist);
-  const t = Math.log(hz / fLo) / Math.log(fHi / fLo);
-  return t * w;
+	const fLo = 20;
+	const fHi = Math.min(20000, nyquist);
+	const t = Math.log(hz / fLo) / Math.log(fHi / fLo);
+	return t * w;
 }
 
 // Gutters reserved outside the plot area so axis labels stay legible — the
@@ -404,188 +454,219 @@ const PLOT_PAD_TOP = 4;
 const PLOT_PAD_RIGHT = 14;
 
 function drawSpectrum(dt: number) {
-  const w = canvas.clientWidth;
-  const h = canvas.clientHeight;
-  ctx.clearRect(0, 0, w, h);
+	const w = canvas.clientWidth;
+	const h = canvas.clientHeight;
+	ctx.clearRect(0, 0, w, h);
 
-  ctx.fillStyle = "#0c0e13";
-  ctx.fillRect(0, 0, w, h);
+	ctx.fillStyle = "#0c0e13";
+	ctx.fillRect(0, 0, w, h);
 
-  // Inner plot rectangle; everything data-driven is drawn inside this.
-  const pl = PLOT_PAD_LEFT;
-  const pt = PLOT_PAD_TOP;
-  const pw = Math.max(1, w - PLOT_PAD_LEFT - PLOT_PAD_RIGHT);
-  const ph = Math.max(1, h - PLOT_PAD_TOP - PLOT_PAD_BOTTOM);
-  const pb = pt + ph; // plot bottom
+	// Inner plot rectangle; everything data-driven is drawn inside this.
+	const pl = PLOT_PAD_LEFT;
+	const pt = PLOT_PAD_TOP;
+	const pw = Math.max(1, w - PLOT_PAD_LEFT - PLOT_PAD_RIGHT);
+	const ph = Math.max(1, h - PLOT_PAD_TOP - PLOT_PAD_BOTTOM);
+	const pb = pt + ph; // plot bottom
 
-  const nyquist = latest ? latest.sampleRate / 2 : 24000;
-  const toY = (db: number) =>
-    pt + ((SPECTRUM_TOP - db) / (SPECTRUM_TOP - SPECTRUM_FLOOR)) * ph;
+	const nyquist = latest ? latest.sampleRate / 2 : 24000;
+	const toY = (db: number) =>
+		pt + ((SPECTRUM_TOP - db) / (SPECTRUM_TOP - SPECTRUM_FLOOR)) * ph;
 
-  ctx.font = "10px ui-monospace, monospace";
-  ctx.lineWidth = 1;
+	ctx.font = '10px "JetBrains Mono", ui-monospace, monospace';
+	ctx.lineWidth = 1;
 
-  // dB grid lines + labels in the left gutter
-  ctx.strokeStyle = "rgba(255,255,255,0.05)";
-  ctx.textBaseline = "middle";
-  ctx.textAlign = "right";
-  for (let db = SPECTRUM_TOP; db >= SPECTRUM_FLOOR; db -= 20) {
-    const y = toY(db);
-    ctx.beginPath();
-    ctx.moveTo(pl, y + 0.5);
-    ctx.lineTo(pl + pw, y + 0.5);
-    ctx.stroke();
-    ctx.fillStyle = "rgba(255,255,255,0.32)";
-    ctx.fillText(`${db}`, pl - 4, y);
-  }
+	// dB grid lines + labels in the left gutter
+	ctx.strokeStyle = "rgba(255,255,255,0.05)";
+	ctx.textBaseline = "middle";
+	ctx.textAlign = "right";
+	for (let db = SPECTRUM_TOP; db >= SPECTRUM_FLOOR; db -= 20) {
+		const y = toY(db);
+		ctx.beginPath();
+		ctx.moveTo(pl, y + 0.5);
+		ctx.lineTo(pl + pw, y + 0.5);
+		ctx.stroke();
+		ctx.fillStyle = "rgba(255,255,255,0.32)";
+		ctx.fillText(`${db}`, pl - 4, y);
+	}
 
-  // frequency grid lines + labels in the bottom gutter
-  ctx.textBaseline = "alphabetic";
-  ctx.textAlign = "center";
-  let lastLabelX = -Infinity;
-  for (const { hz, major } of GRID_HZ) {
-    if (hz >= nyquist) continue;
-    const x = pl + hzToX(hz, pw, nyquist);
-    ctx.strokeStyle = major ? "rgba(255,255,255,0.10)" : "rgba(255,255,255,0.04)";
-    ctx.beginPath();
-    ctx.moveTo(x + 0.5, pt);
-    ctx.lineTo(x + 0.5, pb);
-    ctx.stroke();
-    // Only label major ticks, and skip any that would crowd the previous label
-    // (the log scale compresses the high end where labels would otherwise overlap).
-    if (major && x - lastLabelX >= 24) {
-      ctx.fillStyle = "rgba(255,255,255,0.5)";
-      ctx.fillText(fmtHz(hz), x, h - 3);
-      lastLabelX = x;
-    }
-  }
-  ctx.textAlign = "left";
+	// frequency grid lines + labels in the bottom gutter
+	ctx.textBaseline = "alphabetic";
+	ctx.textAlign = "center";
+	let lastLabelX = -Infinity;
+	for (const { hz, major } of GRID_HZ) {
+		if (hz >= nyquist) continue;
+		const x = pl + hzToX(hz, pw, nyquist);
+		ctx.strokeStyle = major
+			? "rgba(255,255,255,0.10)"
+			: "rgba(255,255,255,0.04)";
+		ctx.beginPath();
+		ctx.moveTo(x + 0.5, pt);
+		ctx.lineTo(x + 0.5, pb);
+		ctx.stroke();
+		// Only label major ticks, and skip any that would crowd the previous label
+		// (the log scale compresses the high end where labels would otherwise overlap).
+		if (major && x - lastLabelX >= 24) {
+			ctx.fillStyle = "rgba(255,255,255,0.5)";
+			ctx.fillText(fmtHz(hz), x, h - 3);
+			lastLabelX = x;
+		}
+	}
+	ctx.textAlign = "left";
 
-  const spec = latest?.spectrum;
-  if (!spec || spec.length === 0) return;
+	const spec = latest?.spectrum;
+	if (!spec || spec.length === 0) return;
 
-  const n = spec.length;
-  if (peaks.length !== n) peaks = new Array(n).fill(SPECTRUM_FLOOR);
+	const n = spec.length;
+	if (peaks.length !== n) peaks = new Array(n).fill(SPECTRUM_FLOOR);
 
-  const barW = pw / n;
+	const barW = pw / n;
 
-  const grad = ctx.createLinearGradient(0, pt, 0, pb);
-  grad.addColorStop(0, "#ff5d5d");
-  grad.addColorStop(0.35, "#ffd24a");
-  grad.addColorStop(0.7, "#54e08a");
-  grad.addColorStop(1, "#2a9d8f");
-  ctx.fillStyle = grad;
+	const grad = ctx.createLinearGradient(0, pt, 0, pb);
+	grad.addColorStop(0, "#ff5d5d");
+	grad.addColorStop(0.35, "#ffd24a");
+	grad.addColorStop(0.7, "#54e08a");
+	grad.addColorStop(1, "#2a9d8f");
+	ctx.fillStyle = grad;
 
-  for (let i = 0; i < n; i++) {
-    const db = Math.max(SPECTRUM_FLOOR, Math.min(SPECTRUM_TOP, spec[i]));
-    const y = toY(db);
-    ctx.fillRect(pl + i * barW, y, barW - 1, pb - y);
+	for (let i = 0; i < n; i++) {
+		const db = Math.max(SPECTRUM_FLOOR, Math.min(SPECTRUM_TOP, spec[i]));
+		const y = toY(db);
+		ctx.fillRect(pl + i * barW, y, barW - 1, pb - y);
 
-    if (db > peaks[i]) peaks[i] = db;
-    else peaks[i] = Math.max(SPECTRUM_FLOOR, peaks[i] - SPECTRUM_PEAK_DECAY_DB_PER_SEC * dt);
-  }
+		if (db > peaks[i]) peaks[i] = db;
+		else
+			peaks[i] = Math.max(
+				SPECTRUM_FLOOR,
+				peaks[i] - SPECTRUM_PEAK_DECAY_DB_PER_SEC * dt,
+			);
+	}
 
-  ctx.fillStyle = "rgba(255,255,255,0.75)";
-  for (let i = 0; i < n; i++) {
-    const y = toY(peaks[i]);
-    ctx.fillRect(pl + i * barW, y - 1, barW - 1, 2);
-  }
+	ctx.fillStyle = "rgba(255,255,255,0.75)";
+	for (let i = 0; i < n; i++) {
+		const y = toY(peaks[i]);
+		ctx.fillRect(pl + i * barW, y - 1, barW - 1, 2);
+	}
 }
 
 function frame(now: number) {
-  const dt = lastFrameTs ? Math.min((now - lastFrameTs) / 1000, MAX_TICK_SEC) : 0;
-  lastFrameTs = now;
-  drawSpectrum(dt);
-  requestAnimationFrame(frame);
+	const dt = lastFrameTs
+		? Math.min((now - lastFrameTs) / 1000, MAX_TICK_SEC)
+		: 0;
+	lastFrameTs = now;
+	drawSpectrum(dt);
+	requestAnimationFrame(frame);
 }
 
 function resetMeasurement() {
-  peaks = [];
-  displayedPeak = PEAK_FLOOR;
-  lastPeakTs = 0;
-  clipLatched = false;
-  tpCard.classList.remove("clipping");
-  clipFlag.classList.remove("on");
-  invoke("reset_integrated").catch((e) => reportError("Reset measurement", e));
+	// Using Reset means the workflow has been learned — retire the hint for good.
+	void markResetHintSeen();
+	peaks = [];
+	displayedPeak = PEAK_FLOOR;
+	lastPeakTs = 0;
+	clipLatched = false;
+	tpCard.classList.remove("clipping");
+	clipFlag.classList.remove("on");
+	invoke("reset_integrated").catch((e) => reportError("Reset measurement", e));
 }
 
 window.addEventListener("DOMContentLoaded", async () => {
-  resizeCanvas();
-  window.addEventListener("resize", resizeCanvas);
+	resizeCanvas();
+	window.addEventListener("resize", resizeCanvas);
 
-  // Load persisted settings before touching the controls. Target/ceiling apply
-  // immediately; device/channels/rate are staged as "pending" and reapplied as
-  // the device list and per-device config load (with validation) below.
-  try {
-    store = await load("settings.json");
-    const dev = (await store.get<string>("device")) ?? "";
-    const ch = await store.get<string>("channels");
-    const sr = await store.get<number>("sampleRate");
-    const tgt = await store.get<number>("target");
-    const ceil = await store.get<number>("ceiling");
-    const auto = await store.get<boolean>("autoStart");
-    if (dev) pendingDevice = dev;
-    if (typeof ch === "string") pendingChannels = ch;
-    if (typeof sr === "number") pendingRate = sr;
-    if (typeof tgt === "number") targetInput.value = String(tgt);
-    if (typeof ceil === "number") ceilingInput.value = String(ceil);
-    autostartInput.checked = auto === true;
-  } catch {
-    // No store yet (first launch) or a read error — fall back to UI defaults.
-  }
+	// Load persisted settings before touching the controls. Target/ceiling apply
+	// immediately; device/channels/rate are staged as "pending" and reapplied as
+	// the device list and per-device config load (with validation) below.
+	try {
+		store = await load("settings.json");
+		const dev = (await store.get<string>("device")) ?? "";
+		const ch = await store.get<string>("channels");
+		const sr = await store.get<number>("sampleRate");
+		const tgt = await store.get<number>("target");
+		const ceil = await store.get<number>("ceiling");
+		const auto = await store.get<boolean>("autoStart");
+		const hintSeen = await store.get<boolean>("resetHintSeen");
+		if (dev) pendingDevice = dev;
+		if (typeof ch === "string") pendingChannels = ch;
+		if (typeof sr === "number") pendingRate = sr;
+		if (typeof tgt === "number") targetInput.value = String(tgt);
+		if (typeof ceil === "number") ceilingInput.value = String(ceil);
+		autostartInput.checked = auto === true;
+		resetHintSeen = hintSeen === true;
+	} catch {
+		// No store yet (first launch) or a read error — fall back to UI defaults.
+	}
 
-  await loadDevices();
+	await loadDevices();
 
-  // Restore is complete; allow control changes to persist from here on.
-  restoring = false;
+	// Restore is complete; allow control changes to persist from here on.
+	restoring = false;
 
-  deviceSelect.addEventListener("change", async () => {
-    await refreshDeviceConfig();
-    void persist();
-  });
-  toggleBtn.addEventListener("click", () => (running ? stop() : start()));
-  resetBtn.addEventListener("click", resetMeasurement);
-  errorDismiss.addEventListener("click", hideError);
-  errorCopy.addEventListener("click", async () => {
-    try {
-      await navigator.clipboard.writeText(errorMessage.textContent ?? "");
-      errorCopy.textContent = "Copied";
-      setTimeout(() => (errorCopy.textContent = "Copy"), 1500);
-    } catch {
-      // Clipboard unavailable — the message is selectable in the banner.
-    }
-  });
-  channelSelect.addEventListener("change", () => void persist());
-  rateSelect.addEventListener("change", () => void persist());
-  autostartInput.addEventListener("change", () => void persist());
-  targetInput.addEventListener("input", () => {
-    if (latest) updateReadouts(latest);
-  });
-  targetInput.addEventListener("change", () => void persist());
-  ceilingInput.addEventListener("input", () => {
-    if (latest) updateReadouts(latest);
-  });
-  ceilingInput.addEventListener("change", () => void persist());
+	deviceSelect.addEventListener("change", async () => {
+		await refreshDeviceConfig();
+		void persist();
+	});
+	startBtn.addEventListener("click", () => void start());
+	stopBtn.addEventListener("click", () => void stop());
+	resetBtn.addEventListener("click", resetMeasurement);
+	hintDismiss.addEventListener("click", () => void markResetHintSeen());
+	errorDismiss.addEventListener("click", hideError);
+	errorCopy.addEventListener("click", async () => {
+		try {
+			await navigator.clipboard.writeText(errorMessage.textContent ?? "");
+			errorCopy.textContent = "Copied";
+			setTimeout(() => (errorCopy.textContent = "Copy"), 1500);
+		} catch {
+			// Clipboard unavailable — the message is selectable in the banner.
+		}
+	});
+	// Custom number steppers: nudge the target input by its step, then fire the
+	// same input/change events typing would, so readouts update and the value
+	// persists through the existing listeners.
+	for (const btn of document.querySelectorAll<HTMLButtonElement>(".num-step")) {
+		btn.addEventListener("click", () => {
+			const input = $<HTMLInputElement>(btn.dataset.for ?? "");
+			if (!input) return;
+			if (btn.dataset.dir === "up") input.stepUp();
+			else input.stepDown();
+			input.dispatchEvent(new Event("input", { bubbles: true }));
+			input.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+	}
 
-  // Optional: auto-start capture when a valid saved device + channels restored.
-  if (
-    autostartInput.checked &&
-    savedDeviceAvailable &&
-    !deviceSelect.disabled &&
-    deviceSelect.value &&
-    channelSelect.value
-  ) {
-    await start();
-  }
+	channelSelect.addEventListener("change", () => void persist());
+	rateSelect.addEventListener("change", () => void persist());
+	autostartInput.addEventListener("change", () => void persist());
+	targetInput.addEventListener("input", () => {
+		if (latest) updateReadouts(latest);
+	});
+	targetInput.addEventListener("change", () => void persist());
+	ceilingInput.addEventListener("input", () => {
+		if (latest) updateReadouts(latest);
+	});
+	ceilingInput.addEventListener("change", () => void persist());
 
-  await listen<Metrics>("meter-update", (event) => {
-    latest = event.payload;
-    updateReadouts(latest);
-  });
+	// Optional: auto-start capture when a valid saved device + channels restored.
+	if (
+		autostartInput.checked &&
+		savedDeviceAvailable &&
+		!deviceSelect.disabled &&
+		deviceSelect.value &&
+		channelSelect.value
+	) {
+		await start();
+	}
 
-  await listen<string>("stream-error", (event) => {
-    handleStreamError(event.payload);
-  });
+	await listen<Metrics>("meter-update", (event) => {
+		latest = event.payload;
+		updateReadouts(latest);
+	});
 
-  requestAnimationFrame(frame);
+	await listen<string>("stream-error", (event) => {
+		handleStreamError(event.payload);
+	});
+
+	// Wait for the bundled fonts before the first draw so the canvas spectrum
+	// labels render in JetBrains Mono rather than briefly flashing a fallback.
+	await document.fonts.ready;
+	requestAnimationFrame(frame);
 });

--- a/src/styles.css
+++ b/src/styles.css
@@ -6,8 +6,9 @@
   --text: #e8ecf4;
   --muted: #8b93a7;
   --accent: #54e08a;
+  --accent-amber: #f2c14e;
   --accent-hot: #ff5d5d;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
 }
 
 * {
@@ -112,9 +113,22 @@ body {
   border-color: transparent;
 }
 
-.btn-primary.running {
-  background: var(--accent-hot);
-  color: #2a0606;
+/* In-session primary: Reset is the action users take between patches, so it
+   carries the amber emphasis while capturing. Distinct from green Start and
+   from red, which is reserved for clip/danger. */
+.btn-reset {
+  background: var(--accent-amber);
+  color: #2a1f06;
+  border-color: transparent;
+}
+
+.btn-reset:hover {
+  background: #ffd24a;
+  border-color: transparent;
+}
+
+.btn[hidden] {
+  display: none;
 }
 
 .status {
@@ -130,6 +144,43 @@ body {
 }
 .status-err {
   color: var(--accent-hot);
+}
+
+/* ---- Reset hint ---- */
+/* Shown once, the first time capture starts, to teach the core workflow: Reset
+   between patch changes. Amber-tinted to tie it to the Reset button it points
+   at. Dismissed (and remembered) on "Got it" or the first Reset click. */
+.hint {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  font-size: 13px;
+  background: rgba(242, 193, 78, 0.12);
+  border-bottom: 1px solid var(--accent-amber);
+}
+.hint[hidden] {
+  display: none;
+}
+.hint-icon {
+  color: var(--accent-amber);
+  font-size: 15px;
+}
+.hint-text {
+  flex: 1;
+}
+.hint-dismiss {
+  background: transparent;
+  border: 1px solid var(--line);
+  color: var(--text);
+  border-radius: 6px;
+  padding: 3px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.hint-dismiss:hover {
+  border-color: var(--muted);
 }
 
 /* ---- Error banner ---- */
@@ -264,7 +315,7 @@ body {
 }
 
 .readout .value {
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-family: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
   font-size: 30px;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
@@ -285,7 +336,7 @@ body {
   margin-top: 4px;
   font-size: 11px;
   color: var(--muted);
-  font-family: ui-monospace, monospace;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
 }
 
 /* True Peak clip indicator */
@@ -331,15 +382,93 @@ body {
   letter-spacing: 0.6px;
 }
 
-.num-input {
-  width: 72px;
+/* Number field: a themed box holding the input plus custom steppers. The native
+   spin buttons are hidden (unreadable on the dark theme and inconsistent across
+   platforms); the steppers below are drawn with CSS so they match everywhere. */
+.num-field {
+  display: inline-flex;
+  align-items: stretch;
+  width: 92px;
   background: var(--panel-2);
-  color: var(--text);
   border: 1px solid var(--line);
   border-radius: 8px;
-  padding: 6px 8px;
-  font-family: ui-monospace, monospace;
+  overflow: hidden;
+}
+
+.num-field:focus-within {
+  border-color: var(--muted);
+}
+
+.num-input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  color: var(--text);
+  border: none;
+  padding: 6px 4px 6px 8px;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
   font-size: 14px;
+  /* Hide the native spinner (Firefox/standards). */
+  appearance: textfield;
+  -moz-appearance: textfield;
+}
+
+.num-input:focus {
+  outline: none;
+}
+
+/* Hide the native spinner (WebKit/Blink). */
+.num-input::-webkit-outer-spin-button,
+.num-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.num-steppers {
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--line);
+}
+
+.num-step {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  width: 18px;
+  padding: 0;
+  border: none;
+  background: var(--panel);
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.num-step + .num-step {
+  border-top: 1px solid var(--line);
+}
+
+.num-step:hover {
+  background: var(--line);
+  color: var(--text);
+}
+
+.num-step:active {
+  color: var(--accent);
+}
+
+/* Crisp up/down triangles drawn with borders — no font glyph dependency. */
+.num-step::before {
+  content: "";
+  border-left: 3px solid transparent;
+  border-right: 3px solid transparent;
+}
+
+.num-step[data-dir="up"]::before {
+  border-bottom: 4px solid currentColor;
+}
+
+.num-step[data-dir="down"]::before {
+  border-top: 4px solid currentColor;
 }
 
 .unit-inline {
@@ -367,7 +496,7 @@ body {
 }
 
 .delta strong {
-  font-family: ui-monospace, monospace;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
   color: var(--text);
   font-size: 16px;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -132,6 +132,65 @@ body {
   color: var(--accent-hot);
 }
 
+/* ---- Error banner ---- */
+/* A persistent, readable home for failures (e.g. capture won't start). Unlike
+   the toolbar status, the full message wraps and is selectable so the user can
+   read and copy it for a bug report. */
+.error-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 14px;
+  background: rgba(255, 93, 93, 0.1);
+  border-bottom: 1px solid var(--accent-hot);
+}
+.error-banner[hidden] {
+  display: none;
+}
+.error-icon {
+  color: var(--accent-hot);
+  font-size: 14px;
+  line-height: 1.45;
+}
+.error-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.error-message {
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text);
+  word-break: break-word;
+  /* Override the global `user-select: none` so the message can be copied. */
+  user-select: text;
+  -webkit-user-select: text;
+}
+.error-report {
+  font-size: 11px;
+  color: var(--muted);
+  user-select: text;
+  -webkit-user-select: text;
+}
+.btn-small {
+  padding: 4px 10px;
+  font-size: 12px;
+}
+.error-dismiss {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font-size: 18px;
+  line-height: 1;
+  padding: 0 4px;
+  cursor: pointer;
+}
+.error-dismiss:hover {
+  color: var(--text);
+}
+
 /* ---- Config row ---- */
 .config-row {
   display: flex;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,26 +5,25 @@ const host = process.env.TAURI_DEV_HOST;
 
 // https://vite.dev/config/
 export default defineConfig(async () => ({
-
-  // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
-  //
-  // 1. prevent Vite from obscuring rust errors
-  clearScreen: false,
-  // 2. tauri expects a fixed port, fail if that port is not available
-  server: {
-    port: 1420,
-    strictPort: true,
-    host: host || false,
-    hmr: host
-      ? {
-          protocol: "ws",
-          host,
-          port: 1421,
-        }
-      : undefined,
-    watch: {
-      // 3. tell Vite to ignore watching `src-tauri`
-      ignored: ["**/src-tauri/**"],
-    },
-  },
+	// Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
+	//
+	// 1. prevent Vite from obscuring rust errors
+	clearScreen: false,
+	// 2. tauri expects a fixed port, fail if that port is not available
+	server: {
+		port: 1420,
+		strictPort: true,
+		host: host || false,
+		hmr: host
+			? {
+					protocol: "ws",
+					host,
+					port: 1421,
+				}
+			: undefined,
+		watch: {
+			// 3. tell Vite to ignore watching `src-tauri`
+			ignored: ["**/src-tauri/**"],
+		},
+	},
 }));


### PR DESCRIPTION
This branch started as the fix for an unactionable capture error and grew into a 0.1.1 release rollup: developer tooling, cross-platform font consistency, and several UX fixes. Two commits — error messaging first, everything else second.

## Error messaging (the original ask)

A user reported *"I receive an error each time I try to start the analysis"* with no detail — because the app gave them none. The start path surfaced raw cpal errors into a tiny, non-selectable toolbar status.

- Map cpal `BuildStreamError` / `PlayStreamError` / `DefaultStreamConfigError` to plain-language messages that name the device, suggest a fix (reconnect, pick another device, try another sample rate), and add an OS-specific microphone-permission hint on opaque backend failures.
- Surface failures in a dismissible banner with the full, selectable message + a **Copy** button and a link to the issue tracker; normalize non-string rejections; log full detail to the console.
- Debug-only `METERMAID_SIMULATE_ERROR` hook to exercise the error UI without unplugging hardware (compiled out of release builds).

## UX

- Default target loudness is now **−20 LUFS** (fresh installs only; a saved target is still restored).
- While capturing, **Reset** is the prominent **amber** primary control (the between-patches action) and **Stop** is a quiet secondary; Reset is hidden when idle. A one-time, persisted hint teaches the workflow.
- Replaced the unreadable native number spinners on **Target/Ceiling** with custom, theme-styled CSS steppers, and widened the field so values like `-20.5` are no longer clipped.

## Cross-platform consistency

- Bundle **Inter** (UI) + **JetBrains Mono** (readouts/spectrum), Latin subset, so typography is identical on macOS, Windows, and Linux instead of falling back to each OS's defaults. Self-hosted; covered by the existing `font-src 'self'` CSP.

## Developer tooling

- **Biome** for TypeScript (lint + format, tab indentation).
- **markdownlint** for Markdown (root config + a `.github` override since templates are fragments); reflowed all Markdown to one line per paragraph.
- A committed **Git pre-commit hook** (`.githooks`, enabled via `core.hooksPath` from the `prepare` script) that lints staged Rust, TypeScript, and Markdown. `pnpm lint` / `pnpm format` scripts; `CONTRIBUTING.md` documents it.

## Release

- Bump to **0.1.1** across `package.json`, `Cargo.toml`, `tauri.conf.json`, `Cargo.lock`; changelog promoted from Unreleased.

## Test plan

- `pnpm lint` (Biome + markdownlint), `pnpm build`, `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test` — all pass (also enforced by the pre-commit hook).
- UI states (idle/running, Reset/Stop, hint dismissal, steppers, font rendering, no value clipping) verified by driving the real frontend.

## Notes for the reviewer / follow-ups

- README download links still point to `v0.1.0`; update them when the 0.1.1 artifacts are published.
- fontsource also ships `.woff` fallbacks that modern Tauri webviews don't use (~140 KB); can be trimmed to woff2-only if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)