### PR TITLE
Auto-refresh input device list on hotplug (0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - The input-device list now updates automatically while the app is idle: plug in or remove a USB/audio device and it appears in (or disappears from) the picker within a couple of seconds, without reopening the dropdown. The current selection is preserved, and if the selected device is unplugged the picker falls back to the system default with a notice that clears once a device is reselected or reconnected.
 
+### Fixed
+
+- The sample-rate picker no longer offers rates that the device only supports under a different channel count or sample format than the one capture actually uses. Such rates would appear selectable and then fail on Start; the picker is now filtered to the configuration the capture stream is built with.
+- Auto-start now begins capture only after the meter and stream-error listeners are registered, so an immediate stream fault on launch is surfaced instead of leaving the UI with controls disabled and no visible error.
+
 ## [0.1.1] - 2026-06-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-23
+
+### Added
+
+- The input-device list now updates automatically while the app is idle: plug in or remove a USB/audio device and it appears in (or disappears from) the picker within a couple of seconds, without reopening the dropdown. The current selection is preserved, and if the selected device is unplugged the picker falls back to the system default with a notice that clears once a device is reselected or reconnected.
+
 ## [0.1.1] - 2026-06-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- The spectrum canvas no longer redraws at the display refresh rate while idle. The render loop now runs only while capturing and otherwise repaints once per state change, eliminating several percent of idle CPU/GPU usage when metering is stopped.
 - The sample-rate picker no longer offers rates that the device only supports under a different channel count or sample format than the one capture actually uses. Such rates would appear selectable and then fail on Start; the picker is now filtered to the configuration the capture stream is built with.
 - Auto-start now begins capture only after the meter and stream-error listeners are registered, so an immediate stream fault on launch is surfaced instead of leaving the UI with controls disabled and no visible error.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metermaid",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.2.0",
   "type": "module",
   "packageManager": "pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26",
   "description": "MeterMaid — a cross-platform LUFS / loudness meter built with Tauri",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "metermaid"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "cpal",
  "ebur128",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metermaid"
-version = "0.1.1"
+version = "0.2.0"
 description = "MeterMaid — LUFS / loudness meter"
 authors = ["David Neal <david@reverentgeek.com>"]
 edition = "2021"

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -474,6 +474,14 @@ pub fn device_config(name: Option<String>) -> Result<DeviceConfig, String> {
     rates.insert(default_sample_rate);
     if let Ok(ranges) = device.supported_input_configs() {
         for range in ranges {
+            // Only offer rates from ranges that match the channel count and
+            // sample format `build_stream` will actually use (the device's
+            // default config). A rate valid only for some other format/channel
+            // count would otherwise appear in the picker and then fail Start
+            // with StreamConfigNotSupported.
+            if range.channels() != channels || range.sample_format() != default.sample_format() {
+                continue;
+            }
             let min = range.min_sample_rate().0;
             let max = range.max_sample_rate().0;
             for &cand in CANDIDATE_RATES.iter() {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeterMaid",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "identifier": "com.davidneal.metermaid",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/main.ts
+++ b/src/main.ts
@@ -377,6 +377,7 @@ async function start() {
 		setStatus(`${info.sampleRate / 1000} kHz · ${mode}`, "ok");
 		hideError();
 		maybeShowResetHint();
+		requestFrame(); // start the render loop (it self-sustains while running)
 	} catch (e) {
 		reportError("Start capture", e);
 	}
@@ -414,6 +415,7 @@ function teardownRunningUi() {
 	// never engaged still gets it next time.
 	resetHint.hidden = true;
 	configControlsEnabled(true);
+	requestFrame(); // one final repaint to clear the bars, then the loop idles
 }
 
 async function stop() {
@@ -478,6 +480,9 @@ function resizeCanvas() {
 	canvas.width = Math.max(1, Math.round(rect.width * dpr));
 	canvas.height = Math.max(1, Math.round(rect.height * dpr));
 	ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+	// Repaint at the new size; while idle the loop is stopped, so without this
+	// the canvas would stay blank/stretched until the next capture.
+	requestFrame();
 }
 
 // Reference grid lines at musically useful frequencies. `major` ticks get a
@@ -624,13 +629,33 @@ function drawSpectrum(dt: number) {
 	}
 }
 
+let rafPending = false;
+
+// Schedule a single spectrum repaint, coalescing repeated requests within the
+// same frame. While capturing, `frame` re-schedules itself for smooth
+// animation; when idle it draws once and stops, so the canvas isn't redrawn at
+// the display refresh rate for a static, data-less plot — that idle redraw was
+// burning several percent CPU (and GPU) for nothing while metering was stopped.
+function requestFrame() {
+	if (rafPending) return;
+	rafPending = true;
+	requestAnimationFrame(frame);
+}
+
 function frame(now: number) {
+	rafPending = false;
 	const dt = lastFrameTs
 		? Math.min((now - lastFrameTs) / 1000, MAX_TICK_SEC)
 		: 0;
 	lastFrameTs = now;
 	drawSpectrum(dt);
-	requestAnimationFrame(frame);
+	// Keep animating only while capturing (live bars + peak-hold decay). Idle,
+	// the plot is static, so stop until a state change requests a repaint.
+	if (running) {
+		requestFrame();
+	} else {
+		lastFrameTs = 0; // next repaint starts fresh (dt = 0), no decay jump
+	}
 }
 
 function resetMeasurement() {
@@ -751,5 +776,5 @@ window.addEventListener("DOMContentLoaded", async () => {
 	// Wait for the bundled fonts before the first draw so the canvas spectrum
 	// labels render in JetBrains Mono rather than briefly flashing a fallback.
 	await document.fonts.ready;
-	requestAnimationFrame(frame);
+	requestFrame();
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -722,17 +722,6 @@ window.addEventListener("DOMContentLoaded", async () => {
 	});
 	ceilingInput.addEventListener("change", () => void persist());
 
-	// Optional: auto-start capture when a valid saved device + channels restored.
-	if (
-		autostartInput.checked &&
-		savedDeviceAvailable &&
-		!deviceSelect.disabled &&
-		deviceSelect.value &&
-		channelSelect.value
-	) {
-		await start();
-	}
-
 	await listen<Metrics>("meter-update", (event) => {
 		latest = event.payload;
 		updateReadouts(latest);
@@ -744,6 +733,20 @@ window.addEventListener("DOMContentLoaded", async () => {
 
 	// Watch for input devices being plugged in or removed while idle.
 	window.setInterval(() => void pollDevices(), DEVICE_POLL_MS);
+
+	// Optional: auto-start capture when a valid saved device + channels restored.
+	// Done after the meter-update/stream-error listeners are registered so an
+	// immediate stream fault on start is surfaced rather than missed — otherwise
+	// the UI could sit with controls disabled and no visible failure.
+	if (
+		autostartInput.checked &&
+		savedDeviceAvailable &&
+		!deviceSelect.disabled &&
+		deviceSelect.value &&
+		channelSelect.value
+	) {
+		await start();
+	}
 
 	// Wait for the bundled fonts before the first draw so the canvas spectrum
 	// labels render in JetBrains Mono rather than briefly flashing a fallback.

--- a/src/main.ts
+++ b/src/main.ts
@@ -176,24 +176,64 @@ function configControlsEnabled(enabled: boolean) {
 	rateSelect.disabled = !enabled;
 }
 
+// Signature of the most recently rendered device set, so the hotplug poller can
+// skip rebuilding the dropdown when nothing has changed.
+let lastDeviceSig = "";
+
+// Whether the toolbar is currently showing a device-availability notice (e.g.
+// "input device disconnected"). Tracked so we can clear it back to idle once the
+// device returns or the user picks another one.
+let deviceNotice = false;
+
+function noteDeviceIssue(text: string) {
+	deviceNotice = true;
+	setStatus(text, "err");
+}
+
+// Clear a lingering device notice once the situation resolves. Leaves a real
+// error banner (and any active capture status) untouched.
+function clearDeviceNotice() {
+	if (!deviceNotice) return;
+	deviceNotice = false;
+	if (!running && errorBanner.hidden) setStatus("stopped", "idle");
+}
+
+function deviceSig(devices: DeviceInfo[]): string {
+	return devices.map((d) => `${d.isDefault ? "*" : ""}${d.name}`).join("\n");
+}
+
+// (Re)render the device <option>s. If `keep` names a device that's still
+// present it stays selected; otherwise the system default (or first device)
+// is selected. Shared by the initial load and the hotplug poller.
+function renderDeviceOptions(devices: DeviceInfo[], keep: string) {
+	deviceSelect.innerHTML = "";
+	if (devices.length === 0) {
+		const opt = document.createElement("option");
+		opt.textContent = "No input devices found";
+		opt.disabled = true;
+		deviceSelect.append(opt);
+		return;
+	}
+	for (const d of devices) {
+		const opt = document.createElement("option");
+		opt.value = d.name;
+		opt.textContent = d.isDefault ? `${d.name} (default)` : d.name;
+		deviceSelect.append(opt);
+	}
+	if (keep && devices.some((d) => d.name === keep)) {
+		deviceSelect.value = keep;
+	} else {
+		const def = devices.find((d) => d.isDefault) ?? devices[0];
+		deviceSelect.value = def.name;
+	}
+}
+
 async function loadDevices() {
 	try {
 		const devices = await invoke<DeviceInfo[]>("list_devices");
-		deviceSelect.innerHTML = "";
-		if (devices.length === 0) {
-			const opt = document.createElement("option");
-			opt.textContent = "No input devices found";
-			opt.disabled = true;
-			deviceSelect.append(opt);
-			return;
-		}
-		for (const d of devices) {
-			const opt = document.createElement("option");
-			opt.value = d.name;
-			opt.textContent = d.isDefault ? `${d.name} (default)` : d.name;
-			if (d.isDefault) opt.selected = true;
-			deviceSelect.append(opt);
-		}
+		renderDeviceOptions(devices, "");
+		lastDeviceSig = deviceSig(devices);
+		if (devices.length === 0) return;
 		// Restore the saved device if it's still present; otherwise leave the
 		// system default selected and surface a notice. When the saved device is
 		// gone we also drop the saved channels/rate so the default device gets its
@@ -205,13 +245,49 @@ async function loadDevices() {
 				savedDeviceAvailable = false;
 				pendingChannels = undefined;
 				pendingRate = undefined;
-				setStatus("saved device unavailable — using default", "err");
+				noteDeviceIssue("saved device unavailable — using default");
 			}
 			pendingDevice = undefined;
 		}
 		await refreshDeviceConfig();
 	} catch (e) {
 		reportError("List input devices", e);
+	}
+}
+
+// How often to re-check the input-device list for hotplug changes.
+const DEVICE_POLL_MS = 2000;
+
+// cpal exposes no device-change callback, so we poll for USB/audio devices
+// being plugged in or removed while the app is idle. We re-list on an interval
+// and rebuild the dropdown only when the set actually changes, preserving the
+// current selection. Skipped during capture (the config controls are locked
+// then) and during restore; a device vanishing mid-capture is already handled
+// by the stream-error path.
+async function pollDevices() {
+	if (running || restoring || deviceSelect.disabled) return;
+	let devices: DeviceInfo[];
+	try {
+		devices = await invoke<DeviceInfo[]>("list_devices");
+	} catch {
+		return; // Transient failure — try again on the next tick.
+	}
+	const sig = deviceSig(devices);
+	if (sig === lastDeviceSig) return;
+	lastDeviceSig = sig;
+	const prev = deviceSelect.value;
+	renderDeviceOptions(devices, prev);
+	if (deviceSelect.value !== prev) {
+		// The selection changed: the previously selected device went away (or the
+		// first device just appeared). Resync the channel/rate pickers, and tell
+		// the user when an active choice was dropped.
+		if (prev) noteDeviceIssue("input device disconnected — using default");
+		else clearDeviceNotice();
+		await refreshDeviceConfig();
+	} else {
+		// Selection survived — the device topology changed but our pick is still
+		// here (e.g. it was just reconnected). Retire any stale notice.
+		clearDeviceNotice();
 	}
 }
 
@@ -603,6 +679,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 
 	deviceSelect.addEventListener("change", async () => {
 		await refreshDeviceConfig();
+		clearDeviceNotice();
 		void persist();
 	});
 	startBtn.addEventListener("click", () => void start());
@@ -664,6 +741,9 @@ window.addEventListener("DOMContentLoaded", async () => {
 	await listen<string>("stream-error", (event) => {
 		handleStreamError(event.payload);
 	});
+
+	// Watch for input devices being plugged in or removed while idle.
+	window.setInterval(() => void pollDevices(), DEVICE_POLL_MS);
 
 	// Wait for the bundled fonts before the first draw so the canvas spectrum
 	// labels render in JetBrains Mono rather than briefly flashing a fallback.


### PR DESCRIPTION
Releases **0.2.0**.

## Auto-refresh input device list on hotplug

Plug in or remove a USB/audio device while the app is **idle** and it appears in (or disappears from) the picker within ~2 seconds — no need to reopen the dropdown or restart.

`cpal` exposes no device-change callback, so the frontend re-lists devices on a 2s interval and rebuilds the dropdown **only when the set actually changes** (compared via a signature), preserving the current selection. Polling is skipped during capture (controls are locked then) and during restore; a device vanishing mid-capture is still handled by the existing `stream-error` teardown.

If the selected device is unplugged, the picker falls back to the system default with an `input device disconnected — using default` notice. The notice clears automatically once the device reconnects (selection preserved) or the user reselects a device.

### Why not filter out microphones?

A related question was whether the device list could exclude microphones. It can't reliably: `cpal` exposes only a device name (no transport/type), built-in mics and USB interfaces overlap as "input devices", and capturing any input on macOS requires the microphone permission regardless. So the list is intentionally left as-is.

## Idle CPU fix

The spectrum `requestAnimationFrame` loop redrew the canvas at the display refresh rate continuously — even while metering was stopped and the plot was static — burning several percent CPU and GPU for nothing. The loop now self-sustains only while capturing and otherwise repaints once per state change (start, stop/teardown, resize, launch) via a coalesced `requestFrame()` helper. Idle canvas CPU/GPU drops to ~zero; capturing visuals are unchanged.

## Review fixes

- **Sample-rate picker offered unsupported configs.** `device_config` now skips supported-config ranges whose channel count or sample format don't match the device default that `build_stream` actually uses, so a rate valid only under some other format/channel range can't be offered and then fail Start with `StreamConfigNotSupported`.
- **Auto-start could miss a one-shot stream error.** Auto-start now runs *after* the `meter-update`/`stream-error` listeners are registered, so an immediate fault on launch is surfaced instead of leaving the UI with controls disabled and no visible error.

## Changes

- `src/main.ts`: `pollDevices()` on a 2s interval; shared `renderDeviceOptions()` helper; device-notice tracking that clears on reconnect/reselect; idle-aware render loop (`requestFrame()`); auto-start moved after listener registration.
- `src-tauri/src/audio.rs`: filter offered sample rates to the default channel count / sample format.
- Version bumped to `0.2.0` (`package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`); changelog updated.

## Testing

- `pnpm tsc --noEmit`, `pnpm lint` (biome + markdownlint), and `cargo check` / clippy — all pass.
- Manual: unplug/replug a USB audio device while idle (leaves/rejoins within ~2s, selection preserved, disconnect notice clears on reconnect/reselect); confirmed idle CPU drop in Activity Monitor with metering stopped (canvas redraw no longer continuous); resize while idle still repaints the grid; capture start/stop animates and clears as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
