### PR TITLE
Add app menu, in-app About dialog, and updater menu item (0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-06-25
+
+### Added
+
+- An application menu with **About MeterMaid** and **Check for Updates…** items — on macOS in the app menu, and on Windows/Linux under a new **Help** menu. Check for Updates runs the same check as the in-app button.
+- A redesigned **About MeterMaid** dialog: a centered in-app panel showing the app version, description, author, and copyright, with clickable links to the author's website, the GitHub repository, and the issue tracker (opened in the default browser).
+
 ## [0.3.0] - 2026-06-25
 
 ### Added

--- a/index.html
+++ b/index.html
@@ -135,5 +135,34 @@
     <section class="spectrum-wrap">
       <canvas id="spectrum"></canvas>
     </section>
+
+    <div id="aboutModal" class="modal-overlay" hidden>
+      <div class="about-dialog" role="dialog" aria-modal="true" aria-labelledby="aboutTitle">
+        <button id="aboutClose" class="modal-close" type="button" aria-label="Close">×</button>
+        <svg class="about-logo" viewBox="88 88 336 336" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <g fill="url(#brand-meter)">
+            <rect x="96"  y="96"  width="32" height="320" rx="12" />
+            <rect x="144" y="166" width="32" height="250" rx="12" />
+            <rect x="192" y="250" width="32" height="166" rx="12" />
+            <rect x="240" y="294" width="32" height="122" rx="12" />
+            <rect x="288" y="250" width="32" height="166" rx="12" />
+            <rect x="336" y="166" width="32" height="250" rx="12" />
+            <rect x="384" y="96"  width="32" height="320" rx="12" />
+          </g>
+        </svg>
+        <h2 id="aboutTitle" class="about-name">MeterMaid</h2>
+        <p class="about-version">version <span id="aboutVersion">—</span></p>
+        <p class="about-desc">A cross-platform LUFS / loudness meter</p>
+        <p class="about-author">Created by David Neal</p>
+        <p class="about-links">
+          <a class="about-link" href="https://reverentgeek.com">reverentgeek.com</a>
+          <span class="about-sep" aria-hidden="true">·</span>
+          <a class="about-link" href="https://github.com/reverentgeek/metermaid">GitHub</a>
+          <span class="about-sep" aria-hidden="true">·</span>
+          <a class="about-link" href="https://github.com/reverentgeek/metermaid/issues">Submit feedback</a>
+        </p>
+        <p class="about-copyright">© 2026 David Neal · MIT License</p>
+      </div>
+    </div>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metermaid",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "description": "MeterMaid — a cross-platform LUFS / loudness meter built with Tauri",
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.11.1",
+    "@tauri-apps/plugin-opener": "^2.5.0",
     "@tauri-apps/plugin-process": "^2.3.0",
     "@tauri-apps/plugin-store": "^2.4.3",
     "@tauri-apps/plugin-updater": "^2.9.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.11.1
         version: 2.11.1
+      '@tauri-apps/plugin-opener':
+        specifier: ^2.5.0
+        version: 2.5.4
       '@tauri-apps/plugin-process':
         specifier: ^2.3.0
         version: 2.3.1
@@ -318,6 +321,9 @@ packages:
     resolution: {integrity: sha512-EElQe8z8uD7Pi5++tJ/UfEwWuK08rd3oCDYdeIbJAb6pZRrxlqmoF5gh5H5YvzmUPhS4IRCaLSsQhvWkrfK+GQ==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-opener@2.5.4':
+    resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
 
   '@tauri-apps/plugin-process@2.3.1':
     resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
@@ -969,6 +975,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.3
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.3
       '@tauri-apps/cli-win32-x64-msvc': 2.11.3
+
+  '@tauri-apps/plugin-opener@2.5.4':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-process@2.3.1':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -79,6 +79,137 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +320,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -400,6 +544,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -860,6 +1013,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,6 +1064,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1022,6 +1223,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1389,6 +1603,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,6 +1907,25 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
 
 [[package]]
 name = "itertools"
@@ -1992,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "metermaid"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cpal",
  "ebur128",
@@ -2002,6 +2241,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-store",
  "tauri-plugin-updater",
@@ -2441,6 +2681,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "open"
+version = "5.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2451,6 +2703,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "osakit"
@@ -2492,6 +2754,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2513,6 +2781,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -2580,6 +2854,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2622,6 +2907,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3340,6 +3639,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3745,6 +4054,28 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-opener"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "url",
+ "windows 0.61.3",
+ "zbus",
 ]
 
 [[package]]
@@ -4333,6 +4664,17 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -5432,6 +5774,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zvariant",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5508,3 +5911,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.3",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.118",
+ "winnow 1.0.3",
+]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metermaid"
-version = "0.3.0"
+version = "0.3.1"
 description = "MeterMaid — LUFS / loudness meter"
 authors = ["David Neal <david@reverentgeek.com>"]
 edition = "2021"
@@ -26,6 +26,7 @@ tauri = { version = "2", features = [] }
 tauri-plugin-store = "2"
 tauri-plugin-window-state = "2"
 tauri-plugin-process = "2"
+tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 cpal = "0.15"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,9 +5,11 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:app:allow-version",
     "store:default",
     "window-state:default",
     "updater:default",
-    "process:allow-restart"
+    "process:allow-restart",
+    "opener:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,7 @@ mod audio;
 use std::sync::mpsc::{self, Sender, SyncSender};
 
 use audio::{Command, DeviceConfig, DeviceInfo, StreamInfo};
-use tauri::State;
+use tauri::{Emitter, State};
 
 /// Tauri-managed application state: a channel to the audio engine thread.
 struct AppState {
@@ -126,6 +126,75 @@ fn window_guard_plugin<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
         .build()
 }
 
+/// Build the desktop application menu, replacing Tauri's default. **About
+/// MeterMaid** and **Check for Updates…** are custom items that signal the
+/// frontend (via the `menu-about` / `menu-check-updates` events) — About opens
+/// an in-app dialog (centered, with clickable links) rather than the native
+/// panel, which can't be centered or hyperlinked.
+///
+/// On macOS these live in the application menu (alongside the standard Edit and
+/// Window submenus). Windows and Linux have no app menu, so they get a window
+/// menu bar with a single **Help** submenu carrying the same two items.
+#[cfg(desktop)]
+fn build_app_menu<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+) -> tauri::Result<tauri::menu::Menu<R>> {
+    use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
+
+    let about = MenuItemBuilder::with_id("about", "About MeterMaid").build(app)?;
+    let check_updates =
+        MenuItemBuilder::with_id("check-for-updates", "Check for Updates…").build(app)?;
+
+    #[cfg(target_os = "macos")]
+    {
+        let app_menu = SubmenuBuilder::new(app, "MeterMaid")
+            .item(&about)
+            .separator()
+            .item(&check_updates)
+            .separator()
+            .services()
+            .separator()
+            .hide()
+            .hide_others()
+            .show_all()
+            .separator()
+            .quit()
+            .build()?;
+
+        let edit_menu = SubmenuBuilder::new(app, "Edit")
+            .undo()
+            .redo()
+            .separator()
+            .cut()
+            .copy()
+            .paste()
+            .select_all()
+            .build()?;
+
+        let window_menu = SubmenuBuilder::new(app, "Window")
+            .minimize()
+            .maximize()
+            .fullscreen()
+            .separator()
+            .close_window()
+            .build()?;
+
+        MenuBuilder::new(app)
+            .items(&[&app_menu, &edit_menu, &window_menu])
+            .build()
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let help_menu = SubmenuBuilder::new(app, "Help")
+            .item(&about)
+            .item(&check_updates)
+            .build()?;
+
+        MenuBuilder::new(app).item(&help_menu).build()
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let (tx, rx) = mpsc::channel::<Command>();
@@ -135,13 +204,18 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_opener::init())
         .plugin(window_guard_plugin());
 
-    // The self-updater is desktop-only; `relaunch` after install comes from the
-    // process plugin above (registered on every platform).
+    // Desktop-only: the self-updater (`relaunch` after install comes from the
+    // process plugin above, registered on every platform) and the app menu. The
+    // menu is set here, before any window is created, so the Windows/Linux menu
+    // bar attaches to the window rather than missing the initial creation.
     #[cfg(desktop)]
     {
-        builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
+        builder = builder
+            .plugin(tauri_plugin_updater::Builder::new().build())
+            .menu(build_app_menu);
     }
 
     builder
@@ -150,6 +224,17 @@ pub fn run() {
             let handle = app.handle().clone();
             std::thread::spawn(move || audio::engine_loop(rx, handle));
             Ok(())
+        })
+        .on_menu_event(|app, event| match event.id().as_ref() {
+            // "Check for Updates…" reuses the frontend's updater flow (same banner
+            // and feedback as the in-app button); "About" opens the in-app dialog.
+            "check-for-updates" => {
+                let _ = app.emit("menu-check-updates", ());
+            }
+            "about" => {
+                let _ = app.emit("menu-about", ());
+            }
+            _ => {}
         })
         .invoke_handler(tauri::generate_handler![
             list_devices,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeterMaid",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.davidneal.metermaid",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,8 +6,10 @@ import "@fontsource/inter/latin-600.css";
 import "@fontsource/inter/latin-700.css";
 import "@fontsource/jetbrains-mono/latin-400.css";
 import "@fontsource/jetbrains-mono/latin-600.css";
+import { getVersion } from "@tauri-apps/api/app";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { load, type Store } from "@tauri-apps/plugin-store";
 import { check, type Update } from "@tauri-apps/plugin-updater";
@@ -89,6 +91,9 @@ const updateMessage = $<HTMLSpanElement>("updateMessage");
 const updateNotes = $<HTMLSpanElement>("updateNotes");
 const updateInstall = $<HTMLButtonElement>("updateInstall");
 const updateDismiss = $<HTMLButtonElement>("updateDismiss");
+const aboutModal = $<HTMLDivElement>("aboutModal");
+const aboutClose = $<HTMLButtonElement>("aboutClose");
+const aboutVersion = $<HTMLSpanElement>("aboutVersion");
 const canvas = $<HTMLCanvasElement>("spectrum");
 const ctx = canvas.getContext("2d")!;
 
@@ -265,6 +270,19 @@ async function installUpdate() {
 		updateDismiss.disabled = false;
 		updateInstall.textContent = "Install & Restart";
 	}
+}
+
+// ---- About dialog --------------------------------------------------------
+// A custom, centered in-app dialog opened from the macOS "About MeterMaid" menu
+// (via the `menu-about` event). Replaces the native panel so the text can be
+// centered and the links are real, clickable links opened in the user's browser
+// through the opener plugin.
+function showAbout() {
+	aboutModal.hidden = false;
+}
+
+function hideAbout() {
+	aboutModal.hidden = true;
 }
 
 function configControlsEnabled(enabled: boolean) {
@@ -813,6 +831,27 @@ window.addEventListener("DOMContentLoaded", async () => {
 	updateDismiss.addEventListener("click", () => {
 		updateBanner.hidden = true;
 	});
+
+	// About dialog: links open in the system browser (not the webview), and a
+	// backdrop click, the close button, or Escape dismisses it.
+	void getVersion().then((v) => {
+		aboutVersion.textContent = v;
+	});
+	aboutModal.addEventListener("click", (e) => {
+		const target = e.target as HTMLElement;
+		const link = target.closest<HTMLAnchorElement>(".about-link");
+		if (link) {
+			e.preventDefault();
+			void openUrl(link.href);
+			return;
+		}
+		if (target === aboutModal) hideAbout();
+	});
+	aboutClose.addEventListener("click", hideAbout);
+	document.addEventListener("keydown", (e) => {
+		if (e.key === "Escape" && !aboutModal.hidden) hideAbout();
+	});
+
 	errorDismiss.addEventListener("click", hideError);
 	errorCopy.addEventListener("click", async () => {
 		try {
@@ -857,6 +896,13 @@ window.addEventListener("DOMContentLoaded", async () => {
 	await listen<string>("stream-error", (event) => {
 		handleStreamError(event.payload);
 	});
+
+	// The macOS "Check for Updates…" menu item routes here so it shares the
+	// in-app button's flow (banner, "up to date"/error feedback).
+	await listen("menu-check-updates", () => void checkForUpdates(true));
+
+	// The macOS "About MeterMaid" menu item opens the in-app About dialog.
+	await listen("menu-about", () => showAbout());
 
 	// Watch for input devices being plugged in or removed while idle.
 	window.setInterval(() => void pollDevices(), DEVICE_POLL_MS);

--- a/src/styles.css
+++ b/src/styles.css
@@ -571,3 +571,92 @@ body {
   height: 100%;
   display: block;
 }
+
+/* ---- About modal ---- */
+/* A custom, centered About dialog (opened from the macOS "About MeterMaid"
+   menu). Replaces the native panel so the text can be centered and the links
+   are real, clickable links (opened in the browser via the opener plugin). */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(5, 7, 11, 0.6);
+}
+.modal-overlay[hidden] {
+  display: none;
+}
+.about-dialog {
+  position: relative;
+  width: min(360px, calc(100vw - 48px));
+  padding: 28px 32px 24px;
+  text-align: center;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.5);
+}
+.about-logo {
+  display: block;
+  width: 56px;
+  height: 56px;
+  margin: 0 auto 10px;
+}
+.about-name {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+}
+.about-version {
+  margin: 2px 0 16px;
+  font-size: 12px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.about-desc {
+  margin: 0 0 14px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+.about-author {
+  margin: 0 0 12px;
+  font-size: 13px;
+}
+.about-links {
+  margin: 0 0 16px;
+  font-size: 13px;
+}
+.about-link {
+  color: var(--accent);
+  text-decoration: none;
+  cursor: pointer;
+}
+.about-link:hover {
+  text-decoration: underline;
+}
+.about-sep {
+  margin: 0 7px;
+  color: var(--muted);
+}
+.about-copyright {
+  margin: 0;
+  font-size: 11px;
+  color: var(--muted);
+}
+.modal-close {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  padding: 2px 6px;
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+}
+.modal-close:hover {
+  color: var(--text);
+}


### PR DESCRIPTION
## Summary

Adds a desktop **application menu** and a redesigned **About** dialog, plus a menu entry point for the updater. Version bumped to **0.3.1**.

- **App menu** with **About MeterMaid** and **Check for Updates…**:
  - **macOS** — in the application menu, alongside standard **Edit** and **Window** submenus.
  - **Windows / Linux** — under a new **Help** menu bar.
  - Both route to the frontend: *Check for Updates* reuses the in-app updater flow (same banner / "up to date" / error feedback as the toolbar button); *About* opens the new dialog.
- **About dialog** replaces the native macOS panel (which can't be centered or carry clickable links): a **centered** in-app modal showing the live app version (`getVersion()`), description, author, and copyright, with **clickable links** to the author's website, the GitHub repo, and the issue tracker — opened in the default browser via `tauri-plugin-opener`. Dismiss via ×, backdrop click, or Escape.

## Changes

- **Rust** (`lib.rs`): `build_app_menu` (`#[cfg(desktop)]`, branches macOS app menu vs. Help menu bar), applied via builder `.menu()` **before** window creation so the Win/Linux menu bar attaches correctly; `on_menu_event` routes `about` / `check-for-updates`. Registers `tauri-plugin-opener`.
- **Capabilities**: add `opener:default` and `core:app:allow-version`.
- **Frontend** (`index.html`, `styles.css`, `main.ts`): About modal markup + centered styling; opens external links via `openUrl`; listens for `menu-about` / `menu-check-updates`.
- **Version → 0.3.1** across the four files + CHANGELOG.

## Testing

- `cargo build`, `cargo clippy -D warnings`, `cargo test` (16 pass), `pnpm build` (tsc), `pnpm lint` — all green on macOS.
- Verified locally on macOS: both menu items, the About dialog, and its links opening in the browser.
- **Note:** the Windows/Linux **Help** menu bar uses the same cross-platform menu API but can't be visually verified on a macOS dev machine — the CI Linux + Windows build jobs exercise that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)