### PR TITLE
Use Node 24 in CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

Bump `actions/setup-node` from **22 → 24** in both `release.yml` and `ci.yml`, so release builds run on Node 24 and CI validates under the same runtime.

## Context

Requested so all release builds use Node 24. The in-flight `v0.3.1` build (Node 22) was cancelled; after this merges, `v0.3.1` is re-tagged to rebuild on Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)