### PR TITLE
Bump actions/github-script v7 → v8 (Node 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Create draft release
         id: create-release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const tag = process.env.GITHUB_REF_NAME;


### PR DESCRIPTION
## Summary

Bumps `actions/github-script@v7` → `@v8` in the `create-release` job.

`@v7` targets **Node 20**, which GitHub is [deprecating for action execution](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). The runner force-ran it on Node 24 and logged a deprecation warning on the `create-release` job. `@v8` declares `node24` natively (verified via its `action.yml`), clearing the warning.

## Notes

- No behavior change — the `createRelease` script is unchanged; this only changes the Node runtime the action executes under.
- Unrelated to the `node-version: 24` we set on `actions/setup-node` (that controls the app-build Node, not the action-execution Node).
- Cosmetic-only: it does not affect release artifacts, so it just needs to be on `main` before the next release. The in-flight v0.3.1 build is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)