### PR TITLE
Fix spectrum starting blank until window resize (0.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-06-25
+
+### Fixed
+
+- The spectrum plot could occasionally start blank when metering began, correcting itself only after the window was resized. The canvas backing store now re-syncs on any layout change (such as bundled fonts finishing loading and reflowing the header), not just on window resizes.
+
 ## [0.3.1] - 2026-06-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metermaid",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "description": "MeterMaid — a cross-platform LUFS / loudness meter built with Tauri",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2231,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "metermaid"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "cpal",
  "ebur128",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metermaid"
-version = "0.3.1"
+version = "0.3.2"
 description = "MeterMaid — LUFS / loudness meter"
 authors = ["David Neal <david@reverentgeek.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeterMaid",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "com.davidneal.metermaid",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/main.ts
+++ b/src/main.ts
@@ -592,8 +592,14 @@ function updateReadouts(m: Metrics) {
 function resizeCanvas() {
 	const dpr = window.devicePixelRatio || 1;
 	const rect = canvas.getBoundingClientRect();
-	canvas.width = Math.max(1, Math.round(rect.width * dpr));
-	canvas.height = Math.max(1, Math.round(rect.height * dpr));
+	const w = Math.max(1, Math.round(rect.width * dpr));
+	const h = Math.max(1, Math.round(rect.height * dpr));
+	// Skip when nothing changed — assigning canvas.width/height clears the buffer
+	// even if the value is identical, and the ResizeObserver below fires an
+	// initial observation plus every layout tick, so guard against pointless work.
+	if (w === canvas.width && h === canvas.height) return;
+	canvas.width = w;
+	canvas.height = h;
 	ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 	// Repaint at the new size; while idle the loop is stopped, so without this
 	// the canvas would stay blank/stretched until the next capture.
@@ -787,7 +793,14 @@ function resetMeasurement() {
 
 window.addEventListener("DOMContentLoaded", async () => {
 	resizeCanvas();
+	// `resize` only fires for window-level changes (and catches DPR changes when
+	// dragging between monitors). It misses layout-driven size changes of the
+	// flex-sized canvas — e.g. when bundled fonts finish loading and reflow the
+	// header — which left the backing store stale and the spectrum blank/cropped
+	// until a manual window resize. Observe the element itself so any size change
+	// re-syncs the backing store.
 	window.addEventListener("resize", resizeCanvas);
+	new ResizeObserver(resizeCanvas).observe(canvas);
 
 	// Load persisted settings before touching the controls. Target/ceiling apply
 	// immediately; device/channels/rate are staged as "pending" and reapplied as


### PR DESCRIPTION
## Summary

Fixes the intermittent bug where the spectrum plot starts blank when metering begins and only corrects itself after a manual window resize.

`resizeCanvas()` syncs the canvas backing store (`canvas.width/height`) from `getBoundingClientRect()`, but it only ran at `DOMContentLoaded` and on window `resize` events. When the bundled fonts finish loading (`await document.fonts.ready`) they reflow the header, changing the flex-sized canvas's CSS height **without a window resize event** — leaving the backing store stale while `drawSpectrum()` uses the current `clientWidth/clientHeight`, so the plot renders into a cropped buffer and looks blank. The font-load timing race is why it only happened occasionally (depends on whether the fonts were already cached).

## Changes

- Observe the canvas element with a `ResizeObserver` so any layout-driven size change re-syncs the backing store, not just window resizes.
- Keep the window `resize` listener — it still catches DPR changes when dragging between monitors with different scaling.
- Guard `resizeCanvas()` against redundant work, since assigning `canvas.width/height` clears the buffer even for an identical value and a `ResizeObserver` fires an initial observation plus on every layout tick.

The rAF-gating contract is preserved: `resizeCanvas()` still triggers a single idle repaint only when the size actually changed.

## Version

Bumped to **0.3.2** across `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, with a `CHANGELOG.md` entry.

## Testing

- `pnpm build` passes (type-check + Vite build).
- Verified locally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)