### PR TITLE
Release 0.3.3: Reset shortcut, About dialog fix, cSpell dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-06-25
+
+### Added
+
+- **Space resets the measurement** while capturing — the leveling loop hits Reset constantly between patches, so the shortcut removes a mouse round-trip from the most-repeated action. It's ignored when focus is in an input, select, or button so Space still types and activates normally there, and the Reset button tooltip advertises it.
+
+### Changed
+
+- The About dialog now puts **Submit feedback** on its own line so it no longer wraps mid-phrase.
+
+### Internal
+
+- Added a committed `cspell.json` project dictionary with the shared domain word list (`cpal`, `ebur128`, `lufs`, `rustfft`, `ringbuf`, `minisign`, …) so editors stop flagging domain terms.
+
 ## [0.3.2] - 2026-06-25
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -38,5 +38,5 @@ Implementation note: a "freeze current spectrum as a background reference" featu
 
 ## Tooling
 
-- [ ] **Frontend UI** - investigate the usefulness of migrating the UI to React, Vue, Solidjs, or some other UI framework. Same for CSS, like TailwindCSS.
+- [x] **Frontend UI framework** — investigated; not worth it. Hot path is canvas (a framework doesn't help raw 2D drawing), the DOM-sync surface is small and stable, and a runtime dep fights the lean-bundle / low-idle-CPU goals. Revisit *only* if interactive stateful UI grows substantially — and then reach for signals (Preact/Solid), not React/Vue. Skip Tailwind: hand-written CSS is fine for a finished single-window design.
 - [ ] **Project cSpell dictionary** — add a shared word list (`nyquist`, `ebur`, `LUFS`, `clippy`, `serde`, `SPSC`, `rustfft`, `hotplug`, …) so the editor stops flagging domain terms on every Markdown/source edit.

--- a/TODO.md
+++ b/TODO.md
@@ -34,9 +34,9 @@ Implementation note: a "freeze current spectrum as a background reference" featu
 - [ ] Spectrum options: linear/log toggle, adjustable averaging/smoothing, peak vs RMS.
 - [ ] Validate readings against `ffmpeg -af ebur128` in an automated test.
 - [ ] **Spectrum hover readout** — show frequency + dB at the cursor (pairs with the dB grid / target-line overlay above; handy for EQ and the reference-curve work).
-- [ ] **Keyboard shortcut for Reset** (e.g. Space) — the leveling loop hits Reset constantly between patches, so a shortcut tightens the core workflow.
+- [x] **Keyboard shortcut for Reset** (Space) — the leveling loop hits Reset constantly between patches, so a shortcut tightens the core workflow. Gated on capture being active and focus not in an input/select/button.
 
 ## Tooling
 
 - [ ] **Frontend UI** - investigate the usefulness of migrating the UI to React, Vue, Solidjs, or some other UI framework. Same for CSS, like TailwindCSS.
-- [ ] **Project cSpell dictionary** — add a shared word list (`nyquist`, `ebur`, `LUFS`, `clippy`, `serde`, `SPSC`, `rustfft`, `hotplug`, …) so the editor stops flagging domain terms on every Markdown/source edit.
+- [x] **Project cSpell dictionary** — committed `cspell.json` at the repo root with the shared domain word list (`nyquist`, `ebur`, `LUFS`, `clippy`, `serde`, `SPSC`, `rustfft`, `hotplug`, `cpal`, `ringbuf`, `minisign`, …), so the editor stops flagging domain terms on every Markdown/source edit. (Editor-agnostic; the per-machine `.vscode/settings.json` is gitignored.)

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "words": [
+    "clippy",
+    "cpal",
+    "dbtp",
+    "deinterleave",
+    "ebur",
+    "ebur128",
+    "hotplug",
+    "lufs",
+    "metermaid",
+    "minisign",
+    "notarization",
+    "notarize",
+    "notarized",
+    "nyquist",
+    "reverentgeek",
+    "ringbuf",
+    "rustfft",
+    "serde",
+    "spsc",
+    "tauri"
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -158,7 +158,8 @@
           <a class="about-link" href="https://reverentgeek.com">reverentgeek.com</a>
           <span class="about-sep" aria-hidden="true">·</span>
           <a class="about-link" href="https://github.com/reverentgeek/metermaid">GitHub</a>
-          <span class="about-sep" aria-hidden="true">·</span>
+        </p>
+        <p class="about-links">
           <a class="about-link" href="https://github.com/reverentgeek/metermaid/issues">Submit feedback</a>
         </p>
         <p class="about-copyright">© 2026 David Neal · MIT License</p>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
       </div>
       <select id="device" class="device-select" title="Input device"></select>
       <button id="start" class="btn btn-primary">Start</button>
-      <button id="reset" class="btn btn-reset" hidden title="Restart the integrated measurement — click after changing a patch">↻ Reset</button>
+      <button id="reset" class="btn btn-reset" hidden title="Restart the integrated measurement — click after changing a patch (or press Space)">↻ Reset</button>
       <button id="stop" class="btn" hidden title="Stop capturing">Stop</button>
       <span id="status" class="status">stopped</span>
     </header>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metermaid",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "description": "MeterMaid — a cross-platform LUFS / loudness meter built with Tauri",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2231,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "metermaid"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "cpal",
  "ebur128",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metermaid"
-version = "0.3.2"
+version = "0.3.3"
 description = "MeterMaid — LUFS / loudness meter"
 authors = ["David Neal <david@reverentgeek.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeterMaid",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "identifier": "com.davidneal.metermaid",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/main.ts
+++ b/src/main.ts
@@ -863,6 +863,18 @@ window.addEventListener("DOMContentLoaded", async () => {
 	aboutClose.addEventListener("click", hideAbout);
 	document.addEventListener("keydown", (e) => {
 		if (e.key === "Escape" && !aboutModal.hidden) hideAbout();
+		// Space resets the measurement — the leveling loop hits Reset constantly
+		// between patches, so a shortcut tightens the core workflow. Gated on the
+		// Reset button being visible (i.e. capturing) and on focus not being in a
+		// field/button, so Space still types/activates normally there.
+		if (e.code === "Space" && !resetBtn.hidden) {
+			const t = e.target as HTMLElement | null;
+			const tag = t?.tagName;
+			if (tag !== "INPUT" && tag !== "BUTTON" && tag !== "SELECT") {
+				e.preventDefault();
+				resetMeasurement();
+			}
+		}
 	});
 
 	errorDismiss.addEventListener("click", hideError);

--- a/src/styles.css
+++ b/src/styles.css
@@ -625,8 +625,11 @@ body {
   font-size: 13px;
 }
 .about-links {
-  margin: 0 0 16px;
+  margin: 0 0 4px;
   font-size: 13px;
+}
+.about-links + .about-links {
+  margin-bottom: 16px;
 }
 .about-link {
   color: var(--accent);


### PR DESCRIPTION
Bundles three small improvements and bumps the patch version to **0.3.3**.

## Changes

- **Space resets the measurement** while capturing — the leveling loop hits Reset constantly between patches, so the shortcut removes a mouse round-trip from the most-repeated action. Gated on capture being active (Reset button visible) and ignored when focus is in an input/select/button, so Space still types and activates normally there. The Reset button tooltip advertises it.
- **About dialog: "Submit feedback" on its own line** — it was wrapping mid-phrase in the links row; now split into two rows.
- **Project cSpell dictionary** — committed `cspell.json` at the repo root with the shared domain word list (`cpal`, `ebur128`, `lufs`, `rustfft`, `ringbuf`, `minisign`, …) so editors stop flagging domain terms. Editor-agnostic, unlike the gitignored per-machine `.vscode/settings.json`.
- **Resolved a TODO**: investigated migrating the UI to a frontend/CSS framework — closed as not worth it (hot path is canvas; small, stable DOM-sync surface; runtime dep fights the lean-bundle / low-idle-CPU goals).

## Version bump

`0.3.2 → 0.3.3` in all four lockstep locations (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `Cargo.lock`) plus a dated `CHANGELOG.md` section.

## Verification

- `pnpm build` — passes
- `pnpm lint` — passes (Biome + markdownlint, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)