### PR TITLE
Fix Netlify publish path (relative to base)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,14 @@
 # Netlify build config for the MeterMaid website, which lives in site/.
-# `base` makes Netlify install + build from that subdirectory; `publish` is
-# the output dir relative to the repo root. App (src-tauri/) changes still
+# `base` makes Netlify install + build from that subdirectory; `command` and
+# `publish` are both resolved RELATIVE TO `base`, so publish is "_site"
+# (Eleventy's output dir inside site/), not "site/_site" — Netlify would join
+# that onto base and look for site/site/_site. App (src-tauri/) changes still
 # trigger a (fast, static) rebuild — kept simple on purpose so the
 # release-published deploy hook is never skipped by an ignore command.
 [build]
   base = "site"
   command = "pnpm run build"
-  publish = "site/_site"
+  publish = "_site"
 
 [build.environment]
   # Netlify preinstalls Node 22 but installs any nvm version on request; 24 is


### PR DESCRIPTION
Netlify resolves the `publish` directory **relative to `base`**, not the repo root. With `base = "site"` and `publish = "site/_site"`, it looked for `site/site/_site` and failed:

```
Deploy did not succeed: Deploy directory 'site/site/_site' does not exist
  publish: /opt/build/repo/site/site/_site
```

Fix: set `publish = "_site"` (Eleventy's output dir, inside the `site/` base). Comment updated to spell out the base-relative resolution so it doesn't get "corrected" back.

Touches only `netlify.toml`, so the path-aware CI runs `build-site` and skips the Rust matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)