### PR TITLE
Remove em-dashes from website content

### DIFF
--- a/site/src/_data/release.js
+++ b/site/src/_data/release.js
@@ -3,7 +3,7 @@
  *
  * Runs once per Eleventy build. It asks the GitHub Releases API for the latest
  * *published* release and derives the version and per-platform download URLs
- * from the actual uploaded assets — so the site's version badge and download
+ * from the actual uploaded assets, so the site's version badge and download
  * buttons update automatically every time the site is rebuilt (e.g. when the
  * `release: published` deploy hook fires; see .github/workflows/site-deploy.yml).
  *

--- a/site/src/_includes/layouts/base.edge
+++ b/site/src/_includes/layouts/base.edge
@@ -18,14 +18,14 @@
 	<meta property="og:type" content="website">
 	<meta property="og:locale" content="en_US">
 	<meta property="og:image" content="{{ site.url }}/images/social-preview.png">
-	<meta property="og:image:alt" content="MeterMaid desktop app metering a stereo input — integrated, short-term, and momentary LUFS readouts above a log-frequency spectrum analyzer.">
+	<meta property="og:image:alt" content="MeterMaid desktop app metering a stereo input: integrated, short-term, and momentary LUFS readouts above a log-frequency spectrum analyzer.">
 
 	{{-- Twitter/X --}}
 	<meta name="twitter:card" content="summary_large_image">
 	<meta name="twitter:title" content="{{ title }}">
 	<meta name="twitter:description" content="{{ description }}">
 	<meta name="twitter:image" content="{{ site.url }}/images/social-preview.png">
-	<meta name="twitter:image:alt" content="MeterMaid desktop app metering a stereo input — integrated, short-term, and momentary LUFS readouts above a log-frequency spectrum analyzer.">
+	<meta name="twitter:image:alt" content="MeterMaid desktop app metering a stereo input: integrated, short-term, and momentary LUFS readouts above a log-frequency spectrum analyzer.">
 
 	{{-- Favicon --}}
 	<link rel="icon" href="/favicon.svg" type="image/svg+xml">
@@ -126,7 +126,7 @@
 						<span class="font-display text-base font-600 text-ink-100">MeterMaid</span>
 					</div>
 					<p class="text-ink-300 text-sm leading-relaxed max-w-md">
-						A free, open-source desktop loudness meter. Built with Tauri — a Rust audio engine and a web UI.
+						A free, open-source desktop loudness meter. Built with Tauri, a Rust audio engine and a web UI.
 					</p>
 				</div>
 				<nav class="flex flex-col sm:items-end gap-2 text-sm" aria-label="Footer">

--- a/site/src/index.edge
+++ b/site/src/index.edge
@@ -1,6 +1,6 @@
 ---
 layout: base
-title: MeterMaid — A real-time LUFS loudness meter for macOS, Windows & Linux
+title: MeterMaid, a real-time LUFS loudness meter for macOS, Windows & Linux
 description: MeterMaid is a free, open-source desktop loudness meter. Measure LUFS to the EBU R128 / ITU-R BS.1770 standard, watch a live frequency spectrum, and level guitar amp and effect patches at matched loudness.
 ---
 
@@ -67,7 +67,7 @@ description: MeterMaid is a free, open-source desktop loudness meter. Measure LU
 		<p class="max-w-2xl mx-auto text-ink-200 text-lg sm:text-xl leading-relaxed mb-10 animate-fade-up delay-300">
 			MeterMaid is a desktop <strong class="text-ink-100 font-600">LUFS loudness meter</strong> with a live frequency
 			spectrum. Measure to the EBU R128 / ITU-R BS.1770 standard and level your guitar amp and effect patches at
-			matched loudness — so you compare tone, not volume.
+			matched loudness, so you compare tone, not volume.
 		</p>
 
 		<div class="flex flex-col sm:flex-row items-center justify-center gap-4 animate-fade-up delay-500">
@@ -145,7 +145,7 @@ description: MeterMaid is a free, open-source desktop loudness meter. Measure LU
 					</svg>
 				</div>
 				<h3 class="font-display text-xl font-600 text-ink-100 mb-2">Target &amp; Apply helper</h3>
-				<p class="text-ink-300 text-sm leading-relaxed">Set a target LUFS and MeterMaid shows the exact gain to apply to hit it — the fastest way to match two patches.</p>
+				<p class="text-ink-300 text-sm leading-relaxed">Set a target LUFS and MeterMaid shows the exact gain to apply to hit it. It's the fastest way to match two patches.</p>
 			</div>
 
 			<div class="feature-card bg-ink-850 border border-ink-700 p-7 rounded-lg">
@@ -165,7 +165,7 @@ description: MeterMaid is a free, open-source desktop loudness meter. Measure LU
 					</svg>
 				</div>
 				<h3 class="font-display text-xl font-600 text-ink-100 mb-2">Cross-platform &amp; signed</h3>
-				<p class="text-ink-300 text-sm leading-relaxed">Native builds for macOS, Windows, and Linux. macOS builds are signed with an Apple Developer ID and notarized — no Gatekeeper warnings.</p>
+				<p class="text-ink-300 text-sm leading-relaxed">Native builds for macOS, Windows, and Linux. macOS builds are signed with an Apple Developer ID and notarized, with no Gatekeeper warnings.</p>
 			</div>
 
 			<div class="feature-card bg-ink-850 border border-ink-700 p-7 rounded-lg">
@@ -191,7 +191,7 @@ description: MeterMaid is a free, open-source desktop loudness meter. Measure LU
 			<h2 class="font-display text-3xl sm:text-4xl font-700 tracking-tight text-ink-100 mb-5">
 				Get MeterMaid <span class="text-ink-300 font-500 text-2xl">v{{ release.version }}</span></h2>
 			<p class="text-ink-200 leading-relaxed">
-				Pick your platform below. On first launch MeterMaid asks for microphone access — it needs that to read any
+				Pick your platform below. On first launch MeterMaid asks for microphone access. It needs that to read any
 				audio input device, including USB interfaces.
 			</p>
 		</div>
@@ -216,7 +216,7 @@ description: MeterMaid is a free, open-source desktop loudness meter. Measure LU
 						<span>Intel (.dmg)</span><span class="font-mono text-xs text-ink-300">x64</span>
 					</a>
 				</div>
-				<p class="mt-4 text-ink-300 text-xs leading-relaxed">Signed &amp; notarized — opens without warnings.</p>
+				<p class="mt-4 text-ink-300 text-xs leading-relaxed">Signed &amp; notarized, so it opens without warnings.</p>
 			</div>
 
 			{{-- Windows --}}
@@ -237,7 +237,7 @@ description: MeterMaid is a free, open-source desktop loudness meter. Measure LU
 						<span>Installer (.exe)</span><span class="font-mono text-xs text-ink-300">arm64</span>
 					</a>
 				</div>
-				<p class="mt-4 text-ink-300 text-xs leading-relaxed">Unsigned — SmartScreen may warn; choose <em>More info → Run anyway</em>. <code class="font-mono">.msi</code> in <a href="{{ release.htmlUrl }}" class="text-green-400 link-underline">all assets</a>.</p>
+				<p class="mt-4 text-ink-300 text-xs leading-relaxed">Unsigned, so SmartScreen may warn; choose <em>More info → Run anyway</em>. <code class="font-mono">.msi</code> in <a href="{{ release.htmlUrl }}" class="text-green-400 link-underline">all assets</a>.</p>
 			</div>
 
 			{{-- Linux --}}
@@ -279,7 +279,7 @@ description: MeterMaid is a free, open-source desktop loudness meter. Measure LU
 			Found a bug? Want a feature?</h2>
 		<p class="max-w-2xl mx-auto text-ink-200 leading-relaxed mb-10">
 			MeterMaid is built in the open. The best way to report a problem, request a feature, or ask a question is on
-			GitHub — it keeps everything in one place and lets others chime in.
+			GitHub. It keeps everything in one place and lets others chime in.
 		</p>
 		<div class="flex flex-col sm:flex-row items-center justify-center gap-4">
 			<a href="{{ site.repo }}/issues/new/choose"


### PR DESCRIPTION
Replaces every em-dash (`—`) in the rendered website copy with grammar-correct alternatives, plus one in a `release.js` doc comment.

Replacements, by punctuation that fits the context:
- **Result/aside clauses → comma:** "matched loudness, so you compare tone…", "notarized, with no Gatekeeper warnings", "Signed & notarized, so it opens without warnings", "Unsigned, so SmartScreen may warn…"
- **Independent clauses → period:** "…asks for microphone access. It needs that…", "…on GitHub. It keeps everything…", "…to hit it. It's the fastest way…"
- **Appositive/elaboration → colon or comma:** image alt text "…stereo input: integrated, short-term, and momentary…", footer "Built with Tauri, a Rust audio engine and a web UI"
- **Page title → comma appositive** (a colon would break the YAML frontmatter): "MeterMaid, a real-time LUFS loudness meter…"

`grep -rn '—' site/src` is now clean; `pnpm test` passes (18/18).

Note: this is a **site-only** change, so it should also demonstrate the path-aware CI — `build-and-test` (the Rust matrix) will show as **Skipped** while `build-site` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)