### PR TITLE
Add Getting started and Updates sections to the site

### DIFF
--- a/site/src/_includes/layouts/base.edge
+++ b/site/src/_includes/layouts/base.edge
@@ -93,6 +93,7 @@
 			<div class="flex items-center gap-6 text-sm font-500">
 				<a href="#features" class="hidden sm:inline-block link-underline text-ink-200 hover:text-ink-100 transition-colors">Features</a>
 				<a href="#download" class="hidden sm:inline-block link-underline text-ink-200 hover:text-ink-100 transition-colors">Download</a>
+				<a href="#getting-started" class="hidden md:inline-block link-underline text-ink-200 hover:text-ink-100 transition-colors">Get started</a>
 				<a href="{{ site.repo }}" class="inline-flex items-center gap-2 text-ink-200 hover:text-green-400 transition-colors" rel="noopener">
 					<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false">
 						<path d="M12 .5C5.73.5.5 5.73.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.79 2.73 1.27 3.4.97.1-.76.41-1.27.74-1.56-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.41-5.25 5.69.42.36.79 1.08.79 2.18v3.23c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.73 18.27.5 12 .5z" />

--- a/site/src/index.edge
+++ b/site/src/index.edge
@@ -271,6 +271,69 @@ description: MeterMaid is a free, open-source desktop loudness meter. Measure LU
 </section>
 
 
+{{-- ═══ GETTING STARTED ═══ --}}
+<section id="getting-started" tabindex="-1" aria-label="Getting started" class="relative bg-ink-950 border-t border-ink-800">
+	<div class="relative z-10 max-w-6xl mx-auto px-6 py-24">
+		<div class="max-w-2xl mb-14">
+			<p class="font-display text-green-400 text-sm font-600 tracking-[0.2em] uppercase mb-4">Getting started</p>
+			<h2 class="font-display text-3xl sm:text-4xl font-700 tracking-tight text-ink-100 mb-5">
+				From download to dialed-in tone</h2>
+			<p class="text-ink-200 leading-relaxed">
+				You'll be reading real loudness in under a minute. No account, no config files, and no manual to read.
+			</p>
+		</div>
+
+		<ol class="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+			<li class="feature-card bg-ink-850 border border-ink-700 p-7 rounded-lg">
+				<span class="flex items-center justify-center w-10 h-10 rounded-lg bg-ink-800 font-display text-xl font-700 text-green-400 mb-5">1</span>
+				<h3 class="font-display text-lg font-600 text-ink-100 mb-2">Install and open</h3>
+				<p class="text-ink-300 text-sm leading-relaxed">Grab the build for your platform above and launch it. macOS builds are notarized, so they open without warnings.</p>
+			</li>
+			<li class="feature-card bg-ink-850 border border-ink-700 p-7 rounded-lg">
+				<span class="flex items-center justify-center w-10 h-10 rounded-lg bg-ink-800 font-display text-xl font-700 text-green-400 mb-5">2</span>
+				<h3 class="font-display text-lg font-600 text-ink-100 mb-2">Pick your input</h3>
+				<p class="text-ink-300 text-sm leading-relaxed">Connect your interface or modeler over USB, or route playback through a virtual device like BlackHole, then choose it in the device dropdown.</p>
+			</li>
+			<li class="feature-card bg-ink-850 border border-ink-700 p-7 rounded-lg">
+				<span class="flex items-center justify-center w-10 h-10 rounded-lg bg-ink-800 font-display text-xl font-700 text-green-400 mb-5">3</span>
+				<h3 class="font-display text-lg font-600 text-ink-100 mb-2">Press Start</h3>
+				<p class="text-ink-300 text-sm leading-relaxed">Click Start and allow microphone access when asked. The readouts and the live spectrum come alive right away.</p>
+			</li>
+			<li class="feature-card bg-ink-850 border border-ink-700 p-7 rounded-lg">
+				<span class="flex items-center justify-center w-10 h-10 rounded-lg bg-ink-800 font-display text-xl font-700 text-green-400 mb-5">4</span>
+				<h3 class="font-display text-lg font-600 text-ink-100 mb-2">Match your loudness</h3>
+				<p class="text-ink-300 text-sm leading-relaxed">Set a Target, play a few seconds, and read the Apply value. To level a patch, make a change, click Reset, and play again until Apply settles.</p>
+			</li>
+		</ol>
+	</div>
+</section>
+
+
+{{-- ═══ UPDATES ═══ --}}
+<section id="updates" tabindex="-1" aria-label="Updates" class="relative bg-ink-900 border-t border-ink-800">
+	<div class="relative z-10 max-w-4xl mx-auto px-6 py-24 text-center">
+		<p class="font-display text-green-400 text-sm font-600 tracking-[0.2em] uppercase mb-4">Updates</p>
+		<h2 class="font-display text-3xl sm:text-4xl font-700 tracking-tight text-ink-100 mb-5">
+			Always on the latest version</h2>
+		<p class="max-w-2xl mx-auto text-ink-200 leading-relaxed mb-4">
+			MeterMaid checks for a new version each time it launches and shows a banner when one is ready. One click
+			installs it and relaunches, so you stay current without hunting for a download.
+		</p>
+		<p class="text-ink-300 text-sm mb-10">The current release is <span class="font-mono text-ink-100">v{{ release.version }}</span>.</p>
+		<div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+			<a href="{{ release.htmlUrl }}"
+				class="inline-flex items-center gap-2 bg-green-400 hover:bg-green-500 text-ink-950 font-display font-600 text-lg px-8 py-4 rounded-lg transition-colors duration-200" rel="noopener">
+				Read the release notes
+			</a>
+			<a href="{{ site.repo }}/releases"
+				class="inline-flex items-center gap-2 border border-ink-600 text-ink-100 font-display font-500 text-lg px-8 py-4 rounded-lg hover:border-green-400 hover:text-green-400 transition-colors duration-200" rel="noopener">
+				See all releases
+			</a>
+		</div>
+	</div>
+</section>
+
+
 {{-- ═══ FEEDBACK ═══ --}}
 <section id="feedback" tabindex="-1" aria-label="Feedback" class="relative bg-ink-950 border-t border-ink-800">
 	<div class="relative z-10 max-w-4xl mx-auto px-6 py-24 text-center">

--- a/site/tests/site.spec.js
+++ b/site/tests/site.spec.js
@@ -36,6 +36,8 @@ test.describe( "Accessibility", () => {
 			"Screenshot",
 			"Features",
 			"Download",
+			"Getting started",
+			"Updates",
 			"Feedback",
 		];
 		for ( const label of expectedLabels ) {


### PR DESCRIPTION
Two new content sections on the landing page, between Download and Feedback.

## Getting started
A four-step card list that walks a new user from download to a leveled patch:
1. **Install and open** — grab the platform build and launch (macOS is notarized)
2. **Pick your input** — USB interface/modeler or a virtual device like BlackHole, chosen in the dropdown
3. **Press Start** — allow mic access; readouts and spectrum go live
4. **Match your loudness** — set a Target, read Apply; Reset + replay to level a patch

Also adds a "Get started" nav link.

## Updates
A friendly, non-technical blurb: MeterMaid auto-checks for updates and installs them in one click. Shows the current version from the live release data, with two buttons:
- **Read the release notes** → the latest release page on GitHub
- **See all releases** → the releases list

No changelog dump, just a link out, as requested.

Site-only change (skips the Rust matrix). No em-dashes. `pnpm test` passes 18/18 (landmark test extended to cover both new sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)