### PR TITLE
Fix MeterMaid on older macOS (Catalina): mic access, build, and dead UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **macOS: input devices not detected and no microphone prompt.** MeterMaid now explicitly requests microphone access via AVFoundation (`AVCaptureDevice`) at launch. cpal's CoreAudio HAL never triggers the OS permission prompt on its own, and on older macOS (e.g. Catalina) the HAL returns an empty input-device list until access is granted — leaving the picker stuck with no devices and no way to grant permission. Requesting access up front raises the prompt; once granted, the device picker repopulates. ([#31](https://github.com/reverentgeek/metermaid/issues/31))
+
 ## [0.4.1] - 2026-06-27
 
 ### Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - **macOS: input devices not detected and no microphone prompt.** MeterMaid now explicitly requests microphone access via AVFoundation (`AVCaptureDevice`) at launch. cpal's CoreAudio HAL never triggers the OS permission prompt on its own, and on older macOS (e.g. Catalina) the HAL returns an empty input-device list until access is granted — leaving the picker stuck with no devices and no way to grant permission. Requesting access up front raises the prompt; once granted, the device picker repopulates. ([#31](https://github.com/reverentgeek/metermaid/issues/31))
+- **Older macOS (Catalina): blank/non-functional UI.** Set the Vite build target to `safari13` so the frontend bundle is transpiled for the older system WebKit shipped on macOS 10.15. Previously the bundle used syntax too new for that WebKit to parse, so the JavaScript silently never executed — the window rendered but every control (device/channel/rate pickers, buttons) was dead. ([#31](https://github.com/reverentgeek/metermaid/issues/31))
 
 ## [0.4.1] - 2026-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-06-28
+
 ### Fixed
 
 - **macOS: input devices not detected and no microphone prompt.** MeterMaid now explicitly requests microphone access via AVFoundation (`AVCaptureDevice`) at launch. cpal's CoreAudio HAL never triggers the OS permission prompt on its own, and on older macOS (e.g. Catalina) the HAL returns an empty input-device list until access is granted — leaving the picker stuck with no devices and no way to grant permission. Requesting access up front raises the prompt; once granted, the device picker repopulates. ([#31](https://github.com/reverentgeek/metermaid/issues/31))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metermaid",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "description": "MeterMaid — a cross-platform LUFS / loudness meter built with Tauri",

--- a/site/content/whatsnew.md
+++ b/site/content/whatsnew.md
@@ -16,6 +16,10 @@
 
 # What's new
 
+## 0.4.2 2026-06-28
+
+Fixed MeterMaid on older Macs running macOS Catalina (10.15). It now asks for microphone permission on first launch and correctly lists your input devices, and all the controls work as expected.
+
 ## 0.4.0 2026-06-27
 
 Multichannel metering on Windows. If you run a multichannel interface like a Line 6 Helix over ASIO, MeterMaid can now read each channel on its own (Ch 1 through 8) instead of just a single mixed signal.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -874,7 +874,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1078,7 +1078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2235,8 +2235,11 @@ dependencies = [
 name = "metermaid"
 version = "0.4.1"
 dependencies = [
+ "block2",
  "cpal",
  "ebur128",
+ "objc2",
+ "objc2-av-foundation",
  "ringbuf",
  "rustfft",
  "serde",
@@ -2308,7 +2311,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2462,6 +2465,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-av-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2",
+ "dispatch2",
+ "objc2",
+ "objc2-avf-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-image-io",
+ "objc2-media-toolbox",
+ "objc2-quartz-core",
+]
+
+[[package]]
 name = "objc2-avf-audio"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2563,6 +2588,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-media"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
+dependencies = [
+ "bitflags 2.13.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-video",
+]
+
+[[package]]
 name = "objc2-core-text"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2572,6 +2612,19 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -2603,6 +2656,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-image-io"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b0446e98cf4a784cc7a0177715ff317eeaa8463841c616cfc78aa4f953c4ea"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2611,6 +2675,18 @@ dependencies = [
  "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-media-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd9fdde720df3da7046bb9097811000c1e7ab5cd579fa89d96b27d56781fb30"
+dependencies = [
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-media",
 ]
 
 [[package]]
@@ -3256,7 +3332,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3312,7 +3388,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3703,7 +3779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4267,10 +4343,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4652,7 +4728,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4681,7 +4757,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5108,7 +5184,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "metermaid"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "block2",
  "cpal",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2472,18 +2472,8 @@ checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
- "dispatch2",
  "objc2",
- "objc2-avf-audio",
- "objc2-core-audio-types",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-core-image",
- "objc2-core-video",
  "objc2-foundation",
- "objc2-image-io",
- "objc2-media-toolbox",
- "objc2-quartz-core",
 ]
 
 [[package]]
@@ -2588,21 +2578,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-core-media"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
-dependencies = [
- "bitflags 2.13.0",
- "dispatch2",
- "objc2",
- "objc2-core-audio",
- "objc2-core-audio-types",
- "objc2-core-foundation",
- "objc2-core-video",
-]
-
-[[package]]
 name = "objc2-core-text"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2612,19 +2587,6 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
-]
-
-[[package]]
-name = "objc2-core-video"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
-dependencies = [
- "bitflags 2.13.0",
- "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-io-surface",
 ]
 
 [[package]]
@@ -2656,17 +2618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-image-io"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b0446e98cf4a784cc7a0177715ff317eeaa8463841c616cfc78aa4f953c4ea"
-dependencies = [
- "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
-]
-
-[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2675,18 +2626,6 @@ dependencies = [
  "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-media-toolbox"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd9fdde720df3da7046bb9097811000c1e7ab5cd579fa89d96b27d56781fb30"
-dependencies = [
- "objc2",
- "objc2-core-audio-types",
- "objc2-core-foundation",
- "objc2-core-media",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,7 +47,18 @@ tauri-plugin-updater = "2"
 # already in the tree transitively; `block2` backs the completion handler.
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
-objc2-av-foundation = { version = "0.3", features = ["AVCaptureDevice", "AVMediaFormat"] }
+# `default-features = false` is load-bearing: the default feature set pulls in
+# `objc2-avf-audio`, which links `AVFAudio.framework` — a framework that only
+# exists on macOS 11+. Linking it breaks the build on Catalina (10.15), exactly
+# the OS this fix targets. `AVCaptureDevice` (the permission API) and
+# `AVMediaFormat` (the `AVMediaTypeAudio` constant) need only AVFoundation,
+# which has shipped since 10.7.
+objc2-av-foundation = { version = "0.3", default-features = false, features = [
+    "std",
+    "block2",
+    "AVCaptureDevice",
+    "AVMediaFormat",
+] }
 block2 = "0.6"
 
 # ASIO host — x64 Windows only. ASIO exposes the device's native channel count

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,18 @@ ringbuf = "0.4"
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"
 
+# macOS microphone permission. cpal talks to the CoreAudio HAL, which is *not*
+# the TCC-aware API: it never raises the OS microphone prompt, and on older
+# macOS (e.g. Catalina) the HAL even returns an *empty* input-device list until
+# access is granted — deadlocking the picker (no devices → can't Start → no
+# prompt → no devices). We break that by explicitly requesting access through
+# AVFoundation (`AVCaptureDevice`), which *does* trigger the prompt. `objc2` is
+# already in the tree transitively; `block2` backs the completion handler.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-av-foundation = { version = "0.3", features = ["AVCaptureDevice", "AVMediaFormat"] }
+block2 = "0.6"
+
 # ASIO host — x64 Windows only. ASIO exposes the device's native channel count
 # (WASAPI shared mode reports only the endpoint default, often mono). There is
 # no ARM64 ASIO SDK, so this feature is scoped to x86_64. Building it requires

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metermaid"
-version = "0.4.1"
+version = "0.4.2"
 description = "MeterMaid — LUFS / loudness meter"
 authors = ["David Neal <david@reverentgeek.com>"]
 edition = "2021"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,6 @@
 mod audio;
+#[cfg(target_os = "macos")]
+mod mac_permissions;
 
 use std::sync::mpsc::{self, Sender, SyncSender};
 
@@ -229,6 +231,12 @@ pub fn run() {
     builder
         .manage(AppState { tx })
         .setup(move |app| {
+            // Ask for microphone access up front so the device picker can
+            // populate (cpal's CoreAudio HAL never raises the prompt itself, and
+            // on older macOS won't even list inputs until access is granted).
+            #[cfg(target_os = "macos")]
+            mac_permissions::request_microphone_access();
+
             let handle = app.handle().clone();
             std::thread::spawn(move || audio::engine_loop(rx, handle));
             Ok(())

--- a/src-tauri/src/mac_permissions.rs
+++ b/src-tauri/src/mac_permissions.rs
@@ -1,0 +1,42 @@
+//! macOS microphone-permission bootstrap.
+//!
+//! cpal drives audio through the CoreAudio HAL, which is **not** the TCC-aware
+//! API: it never raises the OS microphone prompt on its own, and on older macOS
+//! (e.g. Catalina) the HAL returns an *empty* input-device list until access is
+//! granted. That deadlocks the picker — no devices means nothing to select,
+//! which means Start is never pressed, which means the prompt never fires, which
+//! means the list stays empty. We break the cycle by asking AVFoundation for
+//! audio access at launch: `AVCaptureDevice` *is* TCC-aware, so this is what
+//! actually presents the prompt. Once the user grants it, the frontend's idle
+//! device poll repopulates the picker within a couple of seconds.
+//!
+//! `NSMicrophoneUsageDescription` (`Info.plist`) supplies the prompt copy and is
+//! mandatory — without it the OS aborts the process when access is requested.
+
+use block2::RcBlock;
+use objc2::runtime::Bool;
+use objc2_av_foundation::{AVAuthorizationStatus, AVCaptureDevice, AVMediaTypeAudio};
+
+/// Request microphone access if the user hasn't decided yet. A no-op when access
+/// is already granted (enumeration works) or already denied/restricted (only the
+/// user can change that in System Settings → Privacy & Security → Microphone).
+/// Safe to call once at startup, from any thread.
+pub fn request_microphone_access() {
+    // SAFETY: `AVMediaTypeAudio` is a framework-owned constant `NSString`, and
+    // these `AVCaptureDevice` class methods are the documented permission API;
+    // neither takes ownership of our arguments. The completion handler is only a
+    // no-op kept alive for the duration of the (asynchronous) call.
+    unsafe {
+        let media_type =
+            AVMediaTypeAudio.expect("AVMediaTypeAudio is a non-null framework constant");
+        if AVCaptureDevice::authorizationStatusForMediaType(media_type)
+            == AVAuthorizationStatus::NotDetermined
+        {
+            // Presents the prompt asynchronously; the handler runs on an
+            // arbitrary queue once the user responds. We don't need its result —
+            // the idle device poll surfaces the now-visible devices on its own.
+            let handler = RcBlock::new(|_granted: Bool| {});
+            AVCaptureDevice::requestAccessForMediaType_completionHandler(media_type, &handler);
+        }
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeterMaid",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "identifier": "com.davidneal.metermaid",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,12 @@ export default defineConfig(async () => ({
 	//
 	// 1. prevent Vite from obscuring rust errors
 	clearScreen: false,
+	// Transpile the bundle down for older system WebKit (Catalina ships Safari
+	// 13). Vite's default target is ~Safari 14, whose output an older WebKit may
+	// fail to even parse — leaving the whole module silently non-executing.
+	build: {
+		target: "safari13",
+	},
 	// 2. tauri expects a fixed port, fail if that port is not available
 	server: {
 		port: 1420,


### PR DESCRIPTION
Fixes #31 — on an Intel iMac running macOS 10.15.8, MeterMaid installed but saw no input devices, never prompted for microphone access, and (once it could build/run) showed a window with completely unresponsive controls. Reproduced on an older Intel Mac and traced to **three separate problems** stacked behind the one symptom.

## What was wrong, and the fixes

1. **No microphone prompt / empty device list.** cpal talks to audio through the CoreAudio HAL, which is not TCC-aware: it never raises the macOS mic prompt on its own, and on older macOS the HAL returns an *empty* input-device list until access is granted — a deadlock (no devices → can't Start → no prompt → no devices).
   → Request microphone access explicitly via AVFoundation (`AVCaptureDevice`) at launch (macOS only). `NSMicrophoneUsageDescription` was already present. Once granted, the existing idle device poll repopulates the picker.

2. **Couldn't build for Catalina at all.** The `objc2-av-foundation` crate's default features pull in `objc2-avf-audio`, which links `AVFAudio.framework` — a framework that only exists on macOS 11+, breaking the link with `framework not found AVFAudio`.
   → `default-features = false` and opt into just `AVCaptureDevice` + `AVMediaFormat` (+ `std`, `block2`), which need only `AVFoundation` (present since 10.7).

3. **Window rendered but all JS-driven controls were dead.** Vite's default build target (~Safari 14) emitted JavaScript the Safari-13-era system WebKit on 10.15 couldn't parse, so the whole bundle silently never executed.
   → Set Vite `build.target` to `safari13`. Harmless on modern webviews (strict subset).

## Testing

Built for `x86_64-apple-darwin` and verified on the Catalina Intel Mac: the mic permission prompt appears, the device picker lists the input(s), the channel/sample-rate dropdowns and all buttons work, and metering runs. No behavior change on current macOS (the permission call is a no-op once granted; the build target only transpiles).

## Note (not in this PR)

This keeps 0.4.x working on macOS 10.15, but 10.15 is EOL and Tauri/wry is moving away from it (tauri-apps/tauri#15431 — a future `wry` bump may hard-crash on Catalina at startup). Worth deciding separately whether to commit to long-term Catalina support or set a macOS 11 floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)