### PR TITLE
Support all PCM sample formats and dedup the device picker (0.4.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-07-01
+
+### Fixed
+
+- **Linux: "uses an audio format MeterMaid can't read (I32)" on class-compliant USB interfaces.** ALSA typically reports S32_LE (signed 32-bit) as the default input format for class-compliant USB audio devices — e.g. the Line 6 Helix Stadium — but the capture path only handled F32, I16, U16, and I24, so Start failed before a stream was built. Sample conversion is now a single generic, realtime-safe path covering every PCM format cpal can deliver (I8/I16/I24/I32/I64, U8/U16/U24/U32/U64, F64), with a unit test pinning the full-scale-to-±1.0 conversion semantics. Only the DSD bitstream formats remain unsupported. ([#33](https://github.com/reverentgeek/metermaid/issues/33))
+
 ## [0.4.3] - 2026-07-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - **Linux: "uses an audio format MeterMaid can't read (I32)" on class-compliant USB interfaces.** ALSA typically reports S32_LE (signed 32-bit) as the default input format for class-compliant USB audio devices — e.g. the Line 6 Helix Stadium — but the capture path only handled F32, I16, U16, and I24, so Start failed before a stream was built. Sample conversion is now a single generic, realtime-safe path covering every PCM format cpal can deliver (I8/I16/I24/I32/I64, U8/U16/U24/U32/U64, F64), with a unit test pinning the full-scale-to-±1.0 conversion semantics. Only the DSD bitstream formats remain unsupported. ([#33](https://github.com/reverentgeek/metermaid/issues/33))
+- **Linux: the same device no longer appears many times in the picker.** ALSA exposes one physical card as several PCM aliases (`sysdefault`, `front`, `plughw`, …) that share a description, so cpal listed the same name repeatedly. Device identity is the (host-qualified) id and `find_device` resolves an id to its first name match, so the duplicate rows were indistinguishable and all selected the same device anyway; the list now collapses entries that share an id, keeping the first. ([#33](https://github.com/reverentgeek/metermaid/issues/33))
 
 ## [0.4.3] - 2026-07-01
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metermaid",
   "private": true,
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "description": "MeterMaid — a cross-platform LUFS / loudness meter built with Tauri",
@@ -20,7 +20,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
-    "lint": "biome check && markdownlint-cli2 \"**/*.md\" \"#node_modules\"",
+    "lint": "biome check && markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#site/node_modules\"",
     "format": "biome check --write",
     "prepare": "git config core.hooksPath .githooks || true"
   },

--- a/site/content/whatsnew.md
+++ b/site/content/whatsnew.md
@@ -16,6 +16,10 @@
 
 # What's new
 
+## 0.4.4 2026-07-01
+
+Fixed metering on Linux with USB audio interfaces like the Line 6 Helix Stadium. MeterMaid previously could not read the 32 bit audio these devices send on Linux and refused to start; it now handles every common audio format an interface can deliver.
+
 ## 0.4.3 2026-07-01
 
 Reliability fixes, especially for multichannel interfaces.

--- a/site/content/whatsnew.md
+++ b/site/content/whatsnew.md
@@ -18,7 +18,10 @@
 
 ## 0.4.4 2026-07-01
 
-Fixed metering on Linux with USB audio interfaces like the Line 6 Helix Stadium. MeterMaid previously could not read the 32 bit audio these devices send on Linux and refused to start; it now handles every common audio format an interface can deliver.
+Fixes for Linux, especially with USB audio interfaces like the Line 6 Helix Stadium.
+
+- MeterMaid previously could not read the 32 bit audio many USB interfaces send on Linux and refused to start. It now handles every common audio format an interface can deliver.
+- The device picker no longer lists the same interface several times over.
 
 ## 0.4.3 2026-07-01
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "metermaid"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "block2",
  "cpal",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metermaid"
-version = "0.4.3"
+version = "0.4.4"
 description = "MeterMaid — LUFS / loudness meter"
 authors = ["David Neal <david@reverentgeek.com>"]
 edition = "2021"

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -677,6 +677,44 @@ fn push_len(available: usize, vacant: usize, stride: usize) -> usize {
     n - n % stride.max(1)
 }
 
+/// Build an input stream whose samples arrive in a non-f32 PCM format. The
+/// realtime callback converts each sample to f32 into a scratch buffer
+/// pre-sized to the ring capacity (one callback can't exceed a full ring's
+/// worth, so it never reallocates) and pushes whole frames into the SPSC ring.
+/// One generic implementation covers every integer/f64 format a backend may
+/// report, so an unusual driver default (e.g. ALSA's S32_LE) doesn't need its
+/// own hand-written arm.
+fn build_converting_input_stream<T>(
+    device: &cpal::Device,
+    config: cpal::StreamConfig,
+    mut producer: ringbuf::HeapProd<f32>,
+    dropped: Arc<AtomicU64>,
+    stride: usize,
+    cap: usize,
+    on_error: impl FnMut(cpal::Error) + Send + 'static,
+) -> Result<cpal::Stream, cpal::Error>
+where
+    T: cpal::SizedSample + Send + 'static,
+    f32: cpal::FromSample<T>,
+{
+    let mut scratch = vec![0.0f32; cap];
+    device.build_input_stream(
+        config,
+        move |data: &[T], _: &cpal::InputCallbackInfo| {
+            let n = push_len(data.len().min(scratch.len()), producer.vacant_len(), stride);
+            for (dst, &s) in scratch[..n].iter_mut().zip(data) {
+                *dst = f32::from_sample(s);
+            }
+            let _ = producer.push_slice(&scratch[..n]);
+            if n < data.len() {
+                dropped.fetch_add((data.len() - n) as u64, Ordering::Relaxed);
+            }
+        },
+        on_error,
+        None,
+    )
+}
+
 fn build_stream(
     app: &AppHandle,
     device_name: Option<String>,
@@ -763,66 +801,46 @@ fn build_stream(
             on_error,
             None,
         ),
-        cpal::SampleFormat::I16 => {
-            // Pre-sized to the ring capacity so the realtime callback converts
-            // in place and never reallocates (one callback can't exceed a full
-            // ring's worth of samples).
-            let mut scratch = vec![0.0f32; cap];
-            device.build_input_stream(
-                config,
-                move |data: &[i16], _: &cpal::InputCallbackInfo| {
-                    let n = push_len(data.len().min(scratch.len()), producer.vacant_len(), stride);
-                    for (dst, &s) in scratch[..n].iter_mut().zip(data) {
-                        *dst = s as f32 / 32768.0;
-                    }
-                    let _ = producer.push_slice(&scratch[..n]);
-                    if n < data.len() {
-                        cb_dropped.fetch_add((data.len() - n) as u64, Ordering::Relaxed);
-                    }
-                },
-                on_error,
-                None,
-            )
-        }
-        cpal::SampleFormat::U16 => {
-            let mut scratch = vec![0.0f32; cap];
-            device.build_input_stream(
-                config,
-                move |data: &[u16], _: &cpal::InputCallbackInfo| {
-                    let n = push_len(data.len().min(scratch.len()), producer.vacant_len(), stride);
-                    for (dst, &s) in scratch[..n].iter_mut().zip(data) {
-                        *dst = (s as f32 - 32768.0) / 32768.0;
-                    }
-                    let _ = producer.push_slice(&scratch[..n]);
-                    if n < data.len() {
-                        cb_dropped.fetch_add((data.len() - n) as u64, Ordering::Relaxed);
-                    }
-                },
-                on_error,
-                None,
-            )
-        }
-        // 24-bit packed PCM — what pro-audio ASIO drivers (e.g. the Line 6
-        // Helix) report. cpal stores I24 in a 4-byte container; `from_sample`
-        // does the scaled conversion to f32.
-        cpal::SampleFormat::I24 => {
-            let mut scratch = vec![0.0f32; cap];
-            device.build_input_stream(
-                config,
-                move |data: &[cpal::I24], _: &cpal::InputCallbackInfo| {
-                    let n = push_len(data.len().min(scratch.len()), producer.vacant_len(), stride);
-                    for (dst, &s) in scratch[..n].iter_mut().zip(data) {
-                        *dst = f32::from_sample(s);
-                    }
-                    let _ = producer.push_slice(&scratch[..n]);
-                    if n < data.len() {
-                        cb_dropped.fetch_add((data.len() - n) as u64, Ordering::Relaxed);
-                    }
-                },
-                on_error,
-                None,
-            )
-        }
+        // Every other PCM format converts to f32 through the shared scratch
+        // path. Which one arrives is the backend's choice, not the user's:
+        // ASIO drivers (e.g. the Line 6 Helix) report I24, ALSA typically
+        // reports S32_LE (I32) for class-compliant USB interfaces, older
+        // hardware I16/U16.
+        cpal::SampleFormat::I8 => build_converting_input_stream::<i8>(
+            &device, config, producer, cb_dropped, stride, cap, on_error,
+        ),
+        cpal::SampleFormat::I16 => build_converting_input_stream::<i16>(
+            &device, config, producer, cb_dropped, stride, cap, on_error,
+        ),
+        cpal::SampleFormat::I24 => build_converting_input_stream::<cpal::I24>(
+            &device, config, producer, cb_dropped, stride, cap, on_error,
+        ),
+        cpal::SampleFormat::I32 => build_converting_input_stream::<i32>(
+            &device, config, producer, cb_dropped, stride, cap, on_error,
+        ),
+        cpal::SampleFormat::I64 => build_converting_input_stream::<i64>(
+            &device, config, producer, cb_dropped, stride, cap, on_error,
+        ),
+        cpal::SampleFormat::U8 => build_converting_input_stream::<u8>(
+            &device, config, producer, cb_dropped, stride, cap, on_error,
+        ),
+        cpal::SampleFormat::U16 => build_converting_input_stream::<u16>(
+            &device, config, producer, cb_dropped, stride, cap, on_error,
+        ),
+        cpal::SampleFormat::U24 => build_converting_input_stream::<cpal::U24>(
+            &device, config, producer, cb_dropped, stride, cap, on_error,
+        ),
+        cpal::SampleFormat::U32 => build_converting_input_stream::<u32>(
+            &device, config, producer, cb_dropped, stride, cap, on_error,
+        ),
+        cpal::SampleFormat::U64 => build_converting_input_stream::<u64>(
+            &device, config, producer, cb_dropped, stride, cap, on_error,
+        ),
+        cpal::SampleFormat::F64 => build_converting_input_stream::<f64>(
+            &device, config, producer, cb_dropped, stride, cap, on_error,
+        ),
+        // DSD bitstreams (DsdU8/U16/U32) aren't PCM samples; there is no
+        // meaningful per-sample conversion.
         other => {
             return Err(format!(
                 "“{dev_name}” uses an audio format MeterMaid can’t read ({other:?})."
@@ -1189,6 +1207,32 @@ mod tests {
                                             // Already-aligned clamp stays aligned; zero stride must not panic.
         assert_eq!(push_len(960, 96, 6), 96);
         assert_eq!(push_len(960, 100, 0), 100);
+    }
+
+    // --- Sample-format conversion --------------------------------------------
+
+    #[test]
+    fn converted_sample_formats_map_full_scale_to_unity() {
+        // The converting input path relies on cpal's `from_sample` mapping
+        // each PCM format's range onto ±1.0 with the format's origin at 0.0.
+        // Pin those semantics for the formats real backends report: I32 is
+        // ALSA's S32_LE (issue #33, Helix Stadium on Linux), I24 is what ASIO
+        // drivers deliver, I16/U16 come from older hardware.
+        assert_eq!(f32::from_sample(i32::MIN), -1.0);
+        assert_eq!(f32::from_sample(0i32), 0.0);
+        assert_eq!(f32::from_sample(1i32 << 30), 0.5);
+        assert_eq!(f32::from_sample(i16::MIN), -1.0);
+        assert_eq!(f32::from_sample(1i16 << 14), 0.5);
+        assert_eq!(f32::from_sample(u16::MIN), -1.0);
+        assert_eq!(f32::from_sample(1u16 << 15), 0.0);
+        assert_eq!(f32::from_sample(cpal::I24::new(-(1 << 23)).unwrap()), -1.0);
+        assert_eq!(f32::from_sample(cpal::I24::new(1 << 22).unwrap()), 0.5);
+        assert_eq!(f32::from_sample(cpal::U24::new(1 << 23).unwrap()), 0.0);
+        assert_eq!(f32::from_sample(1u32 << 31), 0.0);
+        assert_eq!(f32::from_sample(3u32 << 30), 0.5);
+        assert_eq!(f32::from_sample(i8::MIN), -1.0);
+        assert_eq!(f32::from_sample(u8::MIN), -1.0);
+        assert_eq!(f32::from_sample(0.25f64), 0.25);
     }
 
     // --- Loudness (golden) --------------------------------------------------

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -520,7 +520,21 @@ pub fn list_input_devices(include_asio: bool) -> Result<Vec<DeviceInfo>, String>
         #[cfg(all(windows, target_arch = "x86_64"))]
         append_asio_devices(&mut out);
     }
-    Ok(out)
+    Ok(dedup_devices(out))
+}
+
+/// Collapse entries that share a device id, keeping the first occurrence.
+/// ALSA surfaces one physical card as several PCM aliases (`sysdefault`,
+/// `front`, `plughw`, …) that share a description, so cpal lists the same
+/// name many times over. Device identity *is* the (host-qualified) id —
+/// `find_device` resolves an id to the first name match — so same-id rows
+/// are indistinguishable in the picker and collapsing them loses nothing.
+fn dedup_devices(devices: Vec<DeviceInfo>) -> Vec<DeviceInfo> {
+    let mut seen = BTreeSet::new();
+    devices
+        .into_iter()
+        .filter(|d| seen.insert(d.id.clone()))
+        .collect()
 }
 
 /// Append ASIO-host input devices (x64 Windows). Best-effort: a missing or flaky
@@ -1207,6 +1221,37 @@ mod tests {
                                             // Already-aligned clamp stays aligned; zero stride must not panic.
         assert_eq!(push_len(960, 96, 6), 96);
         assert_eq!(push_len(960, 100, 0), 100);
+    }
+
+    // --- Device listing -------------------------------------------------------
+
+    #[test]
+    fn duplicate_device_ids_are_collapsed() {
+        let mk = |id: &str, host: &str, is_default: bool| DeviceInfo {
+            id: id.to_string(),
+            name: id.trim_start_matches("asio:").to_string(),
+            host: host.to_string(),
+            is_default,
+        };
+        let out = dedup_devices(vec![
+            // ALSA-style aliases: one card listed once per PCM alias.
+            mk("Helix Stadium, USB Audio", "default", false),
+            mk("Helix Stadium, USB Audio", "default", false),
+            mk("HDA Intel PCH, ALC887-VD Analog", "default", true),
+            mk("Helix Stadium, USB Audio", "default", false),
+            // Same bare name under another host keeps its distinct id.
+            mk("asio:Helix Stadium, USB Audio", "asio", false),
+        ]);
+        assert_eq!(
+            out.iter().map(|d| d.id.as_str()).collect::<Vec<_>>(),
+            vec![
+                "Helix Stadium, USB Audio",
+                "HDA Intel PCH, ALC887-VD Analog",
+                "asio:Helix Stadium, USB Audio",
+            ]
+        );
+        // Order is preserved and the default flag survives on the kept row.
+        assert!(out[1].is_default);
     }
 
     // --- Sample-format conversion --------------------------------------------

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeterMaid",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "identifier": "com.davidneal.metermaid",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Linux capture fixes shipping as **0.4.4** (version bump + CHANGELOG + site what's-new included). Fixes #33.

- **Capture from I32 (and every other PCM format) devices** — ALSA reports S32_LE as the default input format for many class-compliant USB interfaces (e.g. the Line 6 Helix Stadium), but `build_stream` only had arms for F32, I16, U16, and I24, so Start failed with "uses an audio format MeterMaid can't read (I32)" before a stream was built. The three hand-written conversion arms are now one generic, realtime-safe `build_converting_input_stream::<T>` (same pre-sized scratch + whole-frame push clamp, no allocation or locking in the callback), routing every PCM format cpal can deliver: I8/I16/I24/I32/I64, U8/U16/U24/U32/U64, F64. F32 keeps its zero-copy path; only the DSD bitstream formats remain in the error arm.
- **Duplicate rows in the device picker** — ALSA surfaces one physical card as several PCM aliases (`sysdefault`, `front`, `plughw`, …) sharing a description, so cpal listed the same name many times (six identical "Helix Stadium, USB Audio" rows in #33). Device identity is the host-qualified id and `find_device` resolves an id to its first name match, so same-id rows were indistinguishable and all selected the same device anyway; `list_input_devices` now collapses them (order-preserving, first occurrence wins). Distinct ids sharing a bare name (`asio:` prefix) are unaffected.
- **Tooling** — `pnpm lint` failed on Tailwind's README when the site's deps were installed locally; the markdownlint glob now also ignores `site/node_modules`.

## Test plan

- [x] `cargo test` — 22 pass, including 2 new: `converted_sample_formats_map_full_scale_to_unity` (pins the full-scale-to-±1.0 `from_sample` semantics the shared conversion path relies on), `duplicate_device_ids_are_collapsed` (ALSA aliases collapse, order preserved, cross-host ids kept)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`, `pnpm lint`
- [x] Verified on Pop!_OS (Parallels VM) with a Line 6 Helix Stadium: Start previously failed with the I32 error and the picker showed duplicate rows; with this branch capture starts and meters, and the picker lists each device once

🤖 Generated with [Claude Code](https://claude.com/claude-code)