### PR TITLE
Ride through recoverable stream errors and fix the Space shortcut focus hijack (0.4.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Linux: a momentary buffer over/underrun no longer stops the meter.** ALSA reports a capture xrun through cpal's error callback, but cpal recovers the stream on its own (re-prepare + restart) — the stream is alive again milliseconds later. MeterMaid treated every stream error as fatal, so a single xrun (routine on machines without realtime scheduling, e.g. cloud VMs) tore down capture with "A buffer underrun or overrun occurred." Stream errors are now classified by `cpal::ErrorKind`: recoverable advisories (`Xrun`, `DeviceChanged`, `RealtimeDenied`) are logged and metering continues; only errors that actually end the stream (device disconnected, stream invalidated, unclassified backend faults) still stop capture and surface in the UI.
 - **Linux/Windows: the last-clicked button could hijack the Space shortcut.** Those webviews leave focus on a clicked button (macOS WebKit doesn't), and the Space-to-Reset shortcut defers to focused controls — so after nudging the LUFS target with the stepper buttons, Space kept stepping the target instead of resetting the measurement. Mouse clicks on buttons no longer move focus (the `mousedown` default action is prevented and the previously focused control is blurred, as the click would have); keyboard behavior — Tab focus, Space/Enter activation — is unchanged.
 
+### Internal
+
+- Added RUSTSEC-2026-0194/0195 (quick-xml < 0.41 DoS on untrusted XML) to the curated `cargo audit` ignore list: quick-xml is only reachable through Tauri's `plist` handling of the app's own trusted plists, and `plist` 1.9.0 (latest) still pins quick-xml 0.39, so no dependency bump can pick up the fix yet. Re-check when plist releases.
+
 ## [0.4.4] - 2026-07-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-07-02
+
+### Fixed
+
+- **Linux: a momentary buffer over/underrun no longer stops the meter.** ALSA reports a capture xrun through cpal's error callback, but cpal recovers the stream on its own (re-prepare + restart) — the stream is alive again milliseconds later. MeterMaid treated every stream error as fatal, so a single xrun (routine on machines without realtime scheduling, e.g. cloud VMs) tore down capture with "A buffer underrun or overrun occurred." Stream errors are now classified by `cpal::ErrorKind`: recoverable advisories (`Xrun`, `DeviceChanged`, `RealtimeDenied`) are logged and metering continues; only errors that actually end the stream (device disconnected, stream invalidated, unclassified backend faults) still stop capture and surface in the UI.
+
 ## [0.4.4] - 2026-07-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - **Linux: a momentary buffer over/underrun no longer stops the meter.** ALSA reports a capture xrun through cpal's error callback, but cpal recovers the stream on its own (re-prepare + restart) — the stream is alive again milliseconds later. MeterMaid treated every stream error as fatal, so a single xrun (routine on machines without realtime scheduling, e.g. cloud VMs) tore down capture with "A buffer underrun or overrun occurred." Stream errors are now classified by `cpal::ErrorKind`: recoverable advisories (`Xrun`, `DeviceChanged`, `RealtimeDenied`) are logged and metering continues; only errors that actually end the stream (device disconnected, stream invalidated, unclassified backend faults) still stop capture and surface in the UI.
+- **Linux/Windows: the last-clicked button could hijack the Space shortcut.** Those webviews leave focus on a clicked button (macOS WebKit doesn't), and the Space-to-Reset shortcut defers to focused controls — so after nudging the LUFS target with the stepper buttons, Space kept stepping the target instead of resetting the measurement. Mouse clicks on buttons no longer move focus (the `mousedown` default action is prevented and the previously focused control is blurred, as the click would have); keyboard behavior — Tab focus, Space/Enter activation — is unchanged.
 
 ## [0.4.4] - 2026-07-01
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metermaid",
   "private": true,
-  "version": "0.4.4",
+  "version": "0.4.5",
   "type": "module",
   "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "description": "MeterMaid — a cross-platform LUFS / loudness meter built with Tauri",

--- a/site/content/whatsnew.md
+++ b/site/content/whatsnew.md
@@ -16,6 +16,10 @@
 
 # What's new
 
+## 0.4.5 2026-07-02
+
+Fixed a Linux bug where a brief audio hiccup could stop metering with a "buffer underrun or overrun" error. These hiccups are harmless and the audio keeps flowing, so MeterMaid now rides through them and keeps metering. It only stops when something is really wrong, like the interface being unplugged.
+
 ## 0.4.4 2026-07-01
 
 Fixes for Linux, especially with USB audio interfaces like the Line 6 Helix Stadium.

--- a/site/content/whatsnew.md
+++ b/site/content/whatsnew.md
@@ -18,7 +18,10 @@
 
 ## 0.4.5 2026-07-02
 
-Fixed a Linux bug where a brief audio hiccup could stop metering with a "buffer underrun or overrun" error. These hiccups are harmless and the audio keeps flowing, so MeterMaid now rides through them and keeps metering. It only stops when something is really wrong, like the interface being unplugged.
+Fixes for Linux and Windows.
+
+- Fixed a Linux bug where a brief audio hiccup could stop metering with a "buffer underrun or overrun" error. These hiccups are harmless and the audio keeps flowing, so MeterMaid now rides through them and keeps metering. It only stops when something is really wrong, like the interface being unplugged.
+- Fixed the spacebar Reset shortcut on Linux and Windows. After clicking a button, such as the Target nudge arrows, pressing space could trigger that button again instead of resetting the measurement. Space now always resets while metering.
 
 ## 0.4.4 2026-07-01
 

--- a/src-tauri/.cargo/audit.toml
+++ b/src-tauri/.cargo/audit.toml
@@ -29,4 +29,12 @@ ignore = [
     "RUSTSEC-2025-0081", # unic-char-property
     "RUSTSEC-2025-0098", # unic-ucd-version
     "RUSTSEC-2025-0100", # unic-ucd-ident
+    # quick-xml < 0.41 DoS on *untrusted* XML (quadratic attribute-name check;
+    # unbounded namespace allocation). Only reachable through `plist` (via
+    # tauri/tauri-utils), which parses the app's own config/bundle plists —
+    # never untrusted input. plist 1.9.0 (latest) still pins quick-xml ^0.39,
+    # so no dependency bump can pick up the fix. Remove both when a plist
+    # release allows quick-xml >= 0.41.
+    "RUSTSEC-2026-0194", # quick-xml
+    "RUSTSEC-2026-0195", # quick-xml
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "metermaid"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "block2",
  "cpal",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metermaid"
-version = "0.4.4"
+version = "0.4.5"
 description = "MeterMaid — LUFS / loudness meter"
 authors = ["David Neal <david@reverentgeek.com>"]
 edition = "2021"

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -691,6 +691,21 @@ fn push_len(available: usize, vacant: usize, stride: usize) -> usize {
     n - n % stride.max(1)
 }
 
+/// Whether a stream error reported by cpal's error callback means the stream
+/// is dead and capture must be torn down. Some kinds are advisories on a
+/// stream that keeps running: after an `Xrun` the ALSA worker re-prepares and
+/// restarts the stream itself (common on machines without realtime
+/// scheduling, e.g. VMs), `DeviceChanged` means the OS already rerouted the
+/// stream, and `RealtimeDenied` only downgrades the audio thread's scheduling.
+/// Unknown kinds (`ErrorKind` is non-exhaustive) stay fatal so a genuinely
+/// dead stream is never left looking healthy.
+fn is_fatal_stream_error(kind: cpal::ErrorKind) -> bool {
+    !matches!(
+        kind,
+        cpal::ErrorKind::Xrun | cpal::ErrorKind::DeviceChanged | cpal::ErrorKind::RealtimeDenied
+    )
+}
+
 /// Build an input stream whose samples arrive in a non-f32 PCM format. The
 /// realtime callback converts each sample to f32 into a scratch buffer
 /// pre-sized to the ring capacity (one callback can't exceed a full ring's
@@ -780,11 +795,14 @@ fn build_stream(
 
     // cpal invokes this on its own thread when the device faults (e.g. it is
     // unplugged mid-capture). Forward it to the UI so the user sees a reason
-    // rather than a silently frozen meter.
+    // rather than a silently frozen meter — but only for faults that actually
+    // end the stream; advisory errors are logged and capture continues.
     let err_app = app.clone();
     let on_error = move |err: cpal::Error| {
         eprintln!("audio stream error: {err}");
-        let _ = err_app.emit("stream-error", err.to_string());
+        if is_fatal_stream_error(err.kind()) {
+            let _ = err_app.emit("stream-error", err.to_string());
+        }
     };
 
     // ASIO needs input and output buffers created together (see
@@ -1221,6 +1239,21 @@ mod tests {
                                             // Already-aligned clamp stays aligned; zero stride must not panic.
         assert_eq!(push_len(960, 96, 6), 96);
         assert_eq!(push_len(960, 100, 0), 100);
+    }
+
+    // --- Stream-error classification ------------------------------------------
+
+    #[test]
+    fn advisory_stream_errors_do_not_tear_down_capture() {
+        // cpal recovers from these itself; the stream keeps running.
+        assert!(!is_fatal_stream_error(cpal::ErrorKind::Xrun));
+        assert!(!is_fatal_stream_error(cpal::ErrorKind::DeviceChanged));
+        assert!(!is_fatal_stream_error(cpal::ErrorKind::RealtimeDenied));
+        // These end the stream (or leave it unusable) and must reach the UI.
+        assert!(is_fatal_stream_error(cpal::ErrorKind::DeviceNotAvailable));
+        assert!(is_fatal_stream_error(cpal::ErrorKind::StreamInvalidated));
+        assert!(is_fatal_stream_error(cpal::ErrorKind::BackendError));
+        assert!(is_fatal_stream_error(cpal::ErrorKind::Other));
     }
 
     // --- Device listing -------------------------------------------------------

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeterMaid",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "identifier": "com.davidneal.metermaid",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/main.ts
+++ b/src/main.ts
@@ -585,8 +585,10 @@ async function stop() {
 	setStatus("stopped", "idle");
 }
 
-// The audio engine emits this when the OS reports a fault on the active stream
-// (e.g. the device is unplugged mid-capture). Tear down and surface why.
+// The audio engine emits this when the OS reports a fault that ends the
+// active stream (e.g. the device is unplugged mid-capture) — recoverable
+// advisories like buffer over/underruns are filtered out engine-side
+// (is_fatal_stream_error). Tear down and surface why.
 function handleStreamError(message: string) {
 	if (!running) return;
 	void invoke("stop_capture").catch(() => {});

--- a/src/main.ts
+++ b/src/main.ts
@@ -937,6 +937,21 @@ window.addEventListener("DOMContentLoaded", async () => {
 		}
 	});
 
+	// Mouse clicks must not park focus on a button: Linux/Windows webviews
+	// focus a clicked button (macOS WebKit doesn't), and the Space guard above
+	// defers to focused BUTTONs — so after clicking, say, a target stepper,
+	// Space kept clicking the stepper instead of resetting. Focus-on-click is
+	// the default action of mousedown; preventing it (and dropping focus from
+	// wherever it was, as the click normally would) keeps Space owned by Reset
+	// after any pointer interaction, while Tab + Space/Enter keyboard
+	// activation of buttons is untouched.
+	document.addEventListener("mousedown", (e) => {
+		if (!(e.target as HTMLElement | null)?.closest("button")) return;
+		e.preventDefault();
+		const active = document.activeElement;
+		if (active instanceof HTMLElement) active.blur();
+	});
+
 	errorDismiss.addEventListener("click", hideError);
 	errorCopy.addEventListener("click", async () => {
 		try {


### PR DESCRIPTION
## Summary

Two fixes discovered while testing 0.4.4 on an ARM64 Ubuntu VM:

- **A momentary buffer over/underrun no longer stops the meter (Linux).** ALSA reports a capture xrun through cpal's error callback, but cpal recovers the stream on its own (re-prepare + restart) — the stream is alive again milliseconds later. MeterMaid treated every stream error as fatal, so a single xrun (routine on machines without realtime scheduling, e.g. VMs) tore down capture with "A buffer underrun or overrun occurred." Stream errors are now classified by `cpal::ErrorKind` (`is_fatal_stream_error`): recoverable advisories (`Xrun`, `DeviceChanged`, `RealtimeDenied`) are logged to stderr and metering continues; everything else — including unknown kinds, since `ErrorKind` is non-exhaustive — still emits `stream-error` and tears down capture.
- **The last-clicked button no longer hijacks the Space shortcut (Linux/Windows).** Those webviews leave focus on a clicked button (macOS WebKit doesn't), and Space-to-Reset defers to focused controls — so after nudging the LUFS target with the stepper buttons, Space kept stepping the target instead of resetting. Mouse clicks on buttons now prevent `mousedown`'s default (the focus move) and blur the previously focused control, as the click normally would; keyboard behavior (Tab focus, Space/Enter activation) is unchanged.

Version bumped to 0.4.5 in all four places, with CHANGELOG and site What's-new entries.

## Test plan

- New unit test `advisory_stream_errors_do_not_tear_down_capture` pins the fatal/advisory classification (no audio device required); `cargo test`, clippy `-D warnings`, `cargo fmt --check`, `pnpm build`, and `pnpm lint` all pass.
- Verified on an ARM64 Ubuntu VM: metering keeps running through xruns, and Space resets after clicking the target steppers instead of re-stepping the target.
- A forced xrun (`kill -STOP $(pgrep -x metermaid); sleep 3; kill -CONT`) logs `audio stream error: ...` on stderr while the meter keeps running; unplugging the device mid-capture still tears down with the error banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)